### PR TITLE
Setup GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-        run: bundle exec rails test
+        run: |
+          bundle exec rake db:create
+          bundle exec rake db:migrate
+          bundle exec rake test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app_test
+        ports: [ "5432:5432" ]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+
+      - name: Install Postgres client
+        run: sudo apt-get -y install libpq-dev
+
+      - name: Install Ruby dependencies
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Install frontend dependencies and build assets
+        run: |
+          yarn install
+          RAILS_ENV=test bundle exec rails webpacker:compile
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bundle exec rails test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Run tests
         env:
+          RUBYOPT: "-W:no-deprecated"
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.1
+          ruby-version: 2.7.0
 
       - name: Install Postgres client
         run: sudo apt-get -y install libpq-dev

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine3.11
+FROM ruby:2.7.0-alpine3.11
 
 # Install dependencies
 RUN apk --update add \

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.7.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.2'


### PR DESCRIPTION
Merge #3 first.

GitHub Actions seem to be a pretty good fit for our requirements, although there are some caveats.

GitHub currently [does not provide Ruby 2.7.1](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) on hosted action runners. I set the ruby version to 2.7.0 in the docker setup and Gemfile to prevent any version warnings.

With GitHub Actions, you create workflow YAML files, and you can only specify when to run them (PR, push to master, …) on a per-workflow basis. As a result, there are two workflows, `tests.yml` and `deploy.yml`. That alone isn’t a problem, but the fact that you can’t share steps between workflows (i.e. building the app) is a bit unfortunate. This results in some duplicated code in both workflow files.

 Still, I think we should use it – it works good enough for now and it’s nice not to have to maintain a separate service.