### PR TITLE
Fix deployments being skipped on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
     needs: test
 
-    if: ${{ github.ref == 'master' }}
+    if: ${{ github.ref == 'refs/head/master' }}
 
     env:
       RUBYOPT: "-W:no-deprecated"


### PR DESCRIPTION
My bad – commits to master weren’t actually deployed.