### PR TITLE
Component generator

### DIFF
--- a/app/components/icon/icon.html.erb
+++ b/app/components/icon/icon.html.erb
@@ -1,3 +1,3 @@
 <svg class="Icon">
-    <use xlink:href="<%= url %>"/>
+    <use href="<%= url %>"/>
 </svg>

--- a/lib/generators/view_component/USAGE
+++ b/lib/generators/view_component/USAGE
@@ -1,0 +1,13 @@
+Description:
+    Creates a new component and spec file.
+    Pass the component name either CamelCase or under_scored.
+
+Example:
+    rails generate component MyButton
+
+    This will create:
+        Component:           app/components/my_button/my_button.rb
+        Template:            app/components/my_button/my_button.html.erb
+        CSS:                 app/components/my_button/my_button.css
+        Stimulus Controller: app/components/my_button/my_button.js
+        Spec:                spec/components/my_button_spec.rb

--- a/lib/generators/view_component/templates/component.css.tt
+++ b/lib/generators/view_component/templates/component.css.tt
@@ -1,0 +1,3 @@
+.<%= class_name.demodulize %> {
+
+}

--- a/lib/generators/view_component/templates/component.html.erb.tt
+++ b/lib/generators/view_component/templates/component.html.erb.tt
@@ -1,0 +1,3 @@
+<div class="<%= class_name.demodulize %>">
+
+</div>

--- a/lib/generators/view_component/templates/component.js.tt
+++ b/lib/generators/view_component/templates/component.js.tt
@@ -1,0 +1,5 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+
+}

--- a/lib/generators/view_component/templates/component.rb.tt
+++ b/lib/generators/view_component/templates/component.rb.tt
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module <%= class_name.deconstantize %>
+  class <%= class_name.demodulize %> < ApplicationComponent
+    def initialize
+
+    end
+  end
+end

--- a/lib/generators/view_component/templates/component_spec.rb.tt
+++ b/lib/generators/view_component/templates/component_spec.rb.tt
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe <%= class_name %>, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { {} }
+  it { should have_css('.<%= class_name.demodulize %>') }
+end

--- a/lib/generators/view_component/view_component_generator.rb
+++ b/lib/generators/view_component/view_component_generator.rb
@@ -1,0 +1,49 @@
+class ViewComponentGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  class_option :css, type: :boolean, default: true
+  class_option :js, type: :boolean, default: true
+  class_option :template, type: :boolean, default: true
+  class_option :spec, type: :boolean, default: true
+
+  BASE_PATH = 'app/components/'
+  SPEC_PATH = 'spec/components/'
+
+  def initialize(args, *options)
+    super
+
+    # Every component should be inside it’s own model,
+    # e.g. my_button will create MyButton::MyButton
+    @class_path.unshift(file_name)
+  end
+
+  def create_class_file
+    template 'component.rb', component_file_path
+  end
+
+  def create_template_file
+    return unless options[:template]
+    template 'component.html.erb', component_file_path('html.erb')
+  end
+
+  def create_css_file
+    return unless options[:css]
+    template 'component.css', component_file_path('css')
+  end
+
+  def create_js_file
+    return unless options[:js]
+    template 'component.js', component_file_path('js')
+  end
+
+  def create_spec_file
+    return unless options[:spec]
+    template 'component_spec.rb', SPEC_PATH + file_name + '_spec.rb'
+  end
+
+  private
+
+  def component_file_path(extension = 'rb')
+    BASE_PATH + file_path + ".#{extension}"
+  end
+end

--- a/spec/components/icon_spec.rb
+++ b/spec/components/icon_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Icon::Icon, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { { icon: 'heart' } }
+  it { should have_css('svg.Icon > use[xlink:href="/icons.svg#nc-icon-heart-glyph-48"]') }
+end

--- a/spec/components/icon_spec.rb
+++ b/spec/components/icon_spec.rb
@@ -6,5 +6,5 @@ RSpec.describe Icon::Icon, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
   let(:params) { { icon: 'heart' } }
-  it { should have_css('svg.Icon > use[xlink:href="/icons.svg#nc-icon-heart-glyph-48"]') }
+  it { should have_css('svg.Icon > use[href="/icons.svg#nc-icon-heart-glyph-48"]') }
 end

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Input::Input, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { {} }
+  it { should have_css('input.Input') }
+
+  describe 'given an id' do
+    let(:params) { { id: 'name' } }
+    it { should have_css('input[id="name"]') }
+  end
+
+  describe 'given a value' do
+    let(:params) { { value: 'Lutra lutra' } }
+    it { should have_css('input[value="Lutra lutra"]') }
+  end
+
+  describe 'when required' do
+    let(:params) { { required: true } }
+    it { should have_css('input[required]') }
+  end
+
+  describe 'given a placeholder' do
+    let(:params) { { placeholder: 'Enter your name here!' } }
+    it { should have_css('input[placeholder="Enter your name here!"]') }
+  end
+end


### PR DESCRIPTION
```
Usage:
  rails generate view_component NAME [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
  [--css], [--no-css]                        # Indicates when to generate css
                                             # Default: true
  [--js], [--no-js]                          # Indicates when to generate js
                                             # Default: true
  [--template], [--no-template]              # Indicates when to generate template
                                             # Default: true
  [--spec], [--no-spec]                      # Indicates when to generate spec
                                             # Default: true

Description:
    Creates a new component and spec file.
    Pass the component name either CamelCase or under_scored.

Example:
    rails generate component MyButton

    This will create:
        Component:           app/components/my_button/my_button.rb
        Template:            app/components/my_button/my_button.html.erb
        CSS:                 app/components/my_button/my_button.css
        Stimulus Controller: app/components/my_button/my_button.js
        Spec:                spec/components/my_button_spec.rb
```