### PR TITLE
Auto-generate request message based on text and hints/text blocks

### DIFF
--- a/app/components/checkbox/checkbox.html.erb
+++ b/app/components/checkbox/checkbox.html.erb
@@ -1,4 +1,11 @@
 <label class="Checkbox">
-  <input id="<%= id %>" name="<%= id %>" data-target="<%= stimulus_target %> class="Checkbox-input" type="checkbox" />
+  <input
+    type="checkbox"
+    id="<%= id %>"
+    name="<%= name %>"
+    value="<%= value %>"
+    data-target="<%= stimulus_target %>"
+    class="Checkbox-input"
+  />
   <span class="Checkbox-label"><%= label %></span>
 </label>

--- a/app/components/checkbox/checkbox.rb
+++ b/app/components/checkbox/checkbox.rb
@@ -2,14 +2,21 @@
 
 module Checkbox
   class Checkbox < ApplicationComponent
-    def initialize(id: nil, label: nil, stimulus_target: nil)
+    def initialize(id: nil, value: nil, group: false, label: nil, stimulus_target: nil)
       @id = id
+      @value = value
+      @group = group
       @label = label
       @stimulus_target = stimulus_target
     end
 
     private
 
-    attr_reader :id, :label, :stimulus_target
+    def name
+      return "#{id}[]" if group
+      return id
+    end
+
+    attr_reader :id, :value, :group, :label, :stimulus_target
   end
 end

--- a/app/components/heading/heading.css
+++ b/app/components/heading/heading.css
@@ -1,10 +1,10 @@
 .Heading {
     line-height: 1.25;
-    font-weight: 700;
+    font-weight: 500;
 }
 
 .Heading--alpha {
-    font-size: 2.25rem;
+    font-size: 1.75rem;
 }
 
 .Heading--beta {

--- a/app/components/page/page.css
+++ b/app/components/page/page.css
@@ -1,0 +1,13 @@
+.Page {
+  padding: var(--spacing-unit);
+  background-color: var(--color-gray-light);
+}
+
+.Page-content {
+  max-width: var(--grid-max-width);
+  margin: auto;
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
+}

--- a/app/components/page/page.html.erb
+++ b/app/components/page/page.html.erb
@@ -1,0 +1,5 @@
+<div class="Page">
+  <div class="Page-content">
+    <%= @content %>
+  </div>
+</div>

--- a/app/components/page/page.rb
+++ b/app/components/page/page.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Page
+  class Page < ApplicationComponent
+    def initialize; end
+  end
+end

--- a/app/components/page_title/page_title.css
+++ b/app/components/page_title/page_title.css
@@ -1,0 +1,5 @@
+.PageTitle {
+  padding: calc(.75 * var(--spacing-unit)) var(--spacing-unit);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
+}

--- a/app/components/page_title/page_title.html.erb
+++ b/app/components/page_title/page_title.html.erb
@@ -1,0 +1,5 @@
+<div class="PageTitle">
+  <%= c 'heading' do %>
+    <%= @content %>
+  <% end %>
+</div>

--- a/app/components/page_title/page_title.rb
+++ b/app/components/page_title/page_title.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PageTitle
+  class PageTitle < ApplicationComponent
+    def initialize(*); end
+  end
+end

--- a/app/components/request_form/request_form.css
+++ b/app/components/request_form/request_form.css
@@ -1,18 +1,22 @@
 .RequestForm {
     display: flex;
-    flex-wrap: wrap;
-}
-
-.RequestForm-form,
-.RequestForm-preview {
-    width: 50%;
     padding: var(--spacing-unit);
-    flex-grow: 0;
-    flex-shrink: 0;
+}
+
+.RequestForm-column {
+    width: 50%;
+}
+
+.RequestForm-column + .RequestForm-column {
+    margin-left: var(--spacing-unit);
 }
 
 .RequestForm-preview {
-    border-left: 1px solid rgba(0, 0, 0, .15);
+    position: sticky;
+    top: var(--spacing-unit);
+    padding: var(--spacing-unit-s);
+    border-radius: var(--border-radius);
+    background-color: var(--color-gray-light);
 }
 
 .RequestForm-preview p + p {

--- a/app/components/request_form/request_form.html.erb
+++ b/app/components/request_form/request_form.html.erb
@@ -1,42 +1,49 @@
 <div class="RequestForm" data-controller="request-form">
-    <div class="RequestForm-form" data-action="input->request-form#updatePreview">
+    <div class="RequestForm-column" data-action="input->request-form#updatePreview">
         <%= c 'stack', space: :large do %>
 
-            <%= c 'field', label: 'Was möchtest du wissen?' do %>
+            <%= c 'field', label: 'Interner Titel', help: 'Damit du zwischen all deinen Fragen den Überblick behältst. Der Titel wird nicht an die Lokalexpert*innen gesandt.' do %>
+                <%= c 'input',
+                    id: :title,
+                    placeholder: 'z.B. Thema der Frage',
+                    required: true
+                %>
+            <% end %>
+
+            <%= c 'field', label: 'Was möchtest du wissen?', help: 'Wähle eine kurze, einfache Formulierung. Beschreibe genau, welche Informationen du benötigst.' do %>
                 <%= c 'textarea',
-                    id: :message,
-                    placeholder: 'Gib hier deine Nachricht ein…',
+                    id: :text,
+                    placeholder: 'Gib hier deine Frage ein…',
+                    required: true,
                     stimulus_target: 'request-form.message'
                 %>
             <% end %>
 
-            <%= c 'field', label: 'Hinweise anhängen', help: 'Erinnere die Teilnehmer*innen, welche Inhalte du benötigst und wofür du sie verwendest. Hierfür gibt es Textbausteine:' do %>
+            <%= c 'field', label: 'Hinweise anhängen', help: 'Erinnere die Lokalexpert*innen, welche Inhalte du benötigst und wofür du sie verwendest. Hierfür gibt es Textbausteine:' do %>
 
                 <%= c 'stack', space: :small do %>
-                    <%= c 'checkbox', label: 'Fotos', stimulus_target: 'request-form.photo' %>
-                    <%= c 'checkbox', label: 'Adressen', stimulus_target: 'request-form.address' %>
-                    <%= c 'checkbox', label: 'Kontaktdaten', stimulus_target: 'request-form.contact' %>
-                    <%= c 'checkbox', label: 'Medizinische Informationen', stimulus_target: 'request-form.medicalInfo' %>
-                    <%= c 'checkbox', label: 'Vertrauliche Informationen', stimulus_target: 'request-form.confidential' %>
+                    <% hints.each do |key, label| %>
+                        <%= c 'checkbox',
+                            id: :hints,
+                            group: true,
+                            value: key,
+                            label: label,
+                            stimulus_target: "request-form.#{key}"
+                        %>
+                    <% end %>
                 <% end %>
 
             <% end %>
 
-            <%= c 'field', label: 'Gibt es eine Deadline für Antworten?' do %>
-                <%= c 'input',
-                    type: 'datetime-local',
-                    value: '2020-05-15T11:30',
-                    stimulus_target: 'request-form.deadline'
-                %>
-            <% end %>
-
-            <%= c 'button', type: 'submit', label: 'Nachricht an alle Kontakte senden' %>
+            <%= c 'button', type: 'submit', label: 'Frage an alle Lokalexpert*innen senden' %>
 
         <% end %>
     </div>
 
-    <div class="RequestForm-preview">
-        <div style="font-weight: 600;margin-bottom:.5rem;">Diese Nachricht erhalten Teilnehmer*innen:</div>
-        <div data-target="request-form.preview"></div>
+    <div class="RequestForm-column">
+        <%= c 'stack', space: :small do %>
+            <strong>Diese Nachricht erhalten die Lokalexpert*innen:</strong>
+            <div class="RequestForm-preview" data-target="request-form.preview"></div>
+        <% end %>
     </div>
 </div>

--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -9,17 +9,17 @@ const NOTE_TEXTS = {
   confidential: 'Textbaustein für vertrauliche Informationen',
 };
 
-const template = ({ message, notes, deadline }) => {
+const template = ({ message, notes }) => {
   message =
     sanitize(message).replace(/\n/g, '<br>') ||
-    '<span class="Placeholder">Nachricht</span>';
+    '<span class="Placeholder">Frage</span>';
 
   notes = Object.entries(notes)
     .filter(([key, isActive]) => isActive)
     .map(([key]) => NOTE_TEXTS[key]);
 
   return `
-        <p>Hallo <span class="Placeholder">Name</span>, die Redaktion hat eine neue Frage an dich!</p>
+        <p>Hallo, die Redaktion hat eine neue Frage an dich:</p>
         <p>${message}</p>
         ${notes.map(note => `<p>${note}</p>`).join('')}
         <p>Vielen Dank für deine Hilfe bei unserer Recherche!</p>
@@ -35,7 +35,6 @@ export default class extends Controller {
     'contact',
     'medicalInfo',
     'confidential',
-    'deadline',
   ];
 
   connect() {
@@ -52,7 +51,6 @@ export default class extends Controller {
         medicalInfo: this.medicalInfoTarget.checked,
         confidential: this.confidentialTarget.checked,
       },
-      deadline: this.deadlineTarget.value,
     };
 
     this.previewTarget.innerHTML = template(data);

--- a/app/components/request_form/request_form.rb
+++ b/app/components/request_form/request_form.rb
@@ -2,6 +2,18 @@
 
 module RequestForm
   class RequestForm < ApplicationComponent
-    def initialize; end
+    HINTS = {
+      photo: 'Fotos',
+      address: 'Adressen',
+      contact: 'Kontaktdaten',
+      medicalInfo: 'Medizinische Informationen',
+      confidential: 'Vertrauliche Informationen'
+    }.freeze
+
+    def initialize(); end
+
+    def hints
+      HINTS
+    end
   end
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -7,14 +7,10 @@ class RequestsController < ApplicationController
   def new; end
 
   def create
-    title = params[:title]
-    text = params[:text]
-    hints = params[:hints]
-
     request = Request.create!(
-      title: title,
-      text: text,
-      hints: hints
+      title: params.fetch(:title),
+      text: params.fetch(:text),
+      hints: params.fetch(:hints, [])
     )
 
     User.where.not(email: nil).find_each do |user|

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -7,16 +7,28 @@ class RequestsController < ApplicationController
   def new; end
 
   def create
-    question = params[:question]
-    Request.create!(text: question)
+    title = params[:title]
+    text = params[:text]
+    hints = params[:hints]
+
+    request = Request.create!(
+      title: title,
+      text: text,
+      hints: hints
+    )
+
     User.where.not(email: nil).find_each do |user|
       QuestionMailer
-        .with(question: question, to: user.email)
+        .with(question: request.plaintext, to: user.email)
         .new_question_email
         .deliver_later
     end
+
     User.where.not(telegram_chat_id: nil).find_each do |user|
-      Telegram.bots[Rails.configuration.bot_id].send_message(chat_id: user.telegram_chat_id, text: question)
+      Telegram.bots[Rails.configuration.bot_id].send_message(
+        chat_id: user.telegram_chat_id,
+        text: request.plaintext
+      )
     end
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,12 +2,28 @@
 
 class Request < ApplicationRecord
   has_many :feedbacks, dependent: :destroy
-
   default_scope { order(:created_at) }
+
+  HINT_TEXTS = {
+    photo: 'Textbaustein für Foto',
+    address: 'Textbaustein für Adressweitergabe',
+    contact: 'Textbaustein für Kontaktweitergabe',
+    medicalInfo: 'Textbaustein für medizinische Informationen',
+    confidential: 'Textbaustein für vertrauliche Informationen',
+  }.freeze
 
   def self.add_reply(answer:, user:)
     recent_request = Request.order('created_at').last
     recent_request || return
     Reply.create(user: user, request: recent_request, text: answer)
+  end
+
+  def deliverable_message
+    parts = []
+    parts << 'Hallo, die Redaktion hat eine neue Frage an dich!'
+    parts << text
+    parts +=  hints.map {|hint| HINT_TEXTS[hint.to_sym] }
+    parts << 'Vielen Dank für deine Hilfe bei unserer Recherche!'
+    parts.join("\n\n")
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,6 +2,7 @@
 
 class Request < ApplicationRecord
   has_many :feedbacks, dependent: :destroy
+  attribute :hints, :string, array: true, default: []
   default_scope { order(:created_at) }
 
   HINT_TEXTS = {
@@ -22,7 +23,7 @@ class Request < ApplicationRecord
     parts = []
     parts << 'Hallo, die Redaktion hat eine neue Frage an dich:'
     parts << text
-    parts +=  hints.map {|hint| HINT_TEXTS[hint.to_sym] }
+    parts += hints.map {|hint| HINT_TEXTS[hint.to_sym] }
     parts << 'Vielen Dank für deine Hilfe bei unserer Recherche!'
     parts.join("\n\n")
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -18,9 +18,9 @@ class Request < ApplicationRecord
     Reply.create(user: user, request: recent_request, text: answer)
   end
 
-  def deliverable_message
+  def plaintext
     parts = []
-    parts << 'Hallo, die Redaktion hat eine neue Frage an dich!'
+    parts << 'Hallo, die Redaktion hat eine neue Frage an dich:'
     parts << text
     parts +=  hints.map {|hint| HINT_TEXTS[hint.to_sym] }
     parts << 'Vielen Dank für deine Hilfe bei unserer Recherche!'

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -1,10 +1,9 @@
-<%= c 'page_wrapper' do %>
+<%= c 'page' do %>
+  <%= c 'page_title' do %>
+    Stelle eine neue Recherchefrage
+  <% end %>
 
-    <%= form_with url: requests_path do %>
-      <%= c 'textarea', id: 'question', required: true, placeholder: 'Gib hier deine Frage ein…' %>
-      <%= c 'button', type: 'submit', label: 'Frage senden' %>
-    <% end %>
-
-  <%= link_to 'Zurück zur Übersicht', :root %>
-
+  <%= form_with url: requests_path, local: true do %>
+    <%= c 'request_form' %>
+  <% end %>
 <% end %>

--- a/db/migrate/20200515151637_add_hints_to_request.rb
+++ b/db/migrate/20200515151637_add_hints_to_request.rb
@@ -1,0 +1,5 @@
+class AddHintsToRequest < ActiveRecord::Migration[6.0]
+  def change
+    add_column :requests, :hints, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_153245) do
+ActiveRecord::Schema.define(version: 2020_05_15_151637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_153245) do
     t.string "text"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "hints", default: [], array: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/frontend/global/base.css
+++ b/frontend/global/base.css
@@ -31,3 +31,8 @@ a {
     color: inherit;
     text-decoration: none;
 }
+
+strong {
+    font-weight: 600;
+}
+

--- a/frontend/global/variables.css
+++ b/frontend/global/variables.css
@@ -8,7 +8,7 @@
     --spacing-unit-l: calc(1.5 * var(--spacing-unit));
     --spacing-unit-xl: calc(2 * var(--spacing-unit));
 
-    --grid-max-width: 44rem;
+    --grid-max-width: 52rem;
 
     --border-radius: 3px;
 

--- a/spec/components/page_spec.rb
+++ b/spec/components/page_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::Page, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { {} }
+  it { should have_css('.Page') }
+end

--- a/spec/components/page_title_spec.rb
+++ b/spec/components/page_title_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PageTitle::PageTitle, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { {} }
+  it { should have_css('.PageTitle') }
+end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Request, type: :model do
   describe '.plaintext' do
     subject { request.plaintext }
 
-    it 'renders correct plaintext message' do
+    it 'returns correct plaintext message' do
       expected  = "Hallo, die Redaktion hat eine neue Frage an dich:\n\n"
       expected += "What is the answer to life, the universe, and everything?\n\n"
       expected += "Textbaustein für Foto\n\n"
@@ -38,7 +38,15 @@ RSpec.describe Request, type: :model do
     end
 
     describe 'without hints' do
-      subject { Request.new(title: 'Example', text: 'Hello World!').plaintext }
+      subject { Request.new(title: 'Example', text: 'Hello World!', hints: []).plaintext }
+
+      it 'returns correct plaintext message' do
+        expected  = "Hallo, die Redaktion hat eine neue Frage an dich:\n\n"
+        expected += "Hello World!\n\n"
+        expected += "Vielen Dank für deine Hilfe bei unserer Recherche!"
+
+        expect(subject).to eql(expected)
+      end
     end
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -19,7 +19,12 @@ RSpec.describe Request, type: :model do
     expect(subject.attributes.keys).to include('title', 'text', 'hints')
   end
 
-  describe 'plaintext' do
+  describe '.hints' do
+    subject { Request.new(title: 'Example').hints }
+    it { should match_array([]) }
+  end
+
+  describe '.plaintext' do
     subject { request.plaintext }
 
     it 'renders correct plaintext message' do
@@ -30,6 +35,10 @@ RSpec.describe Request, type: :model do
       expected += "Vielen Dank für deine Hilfe bei unserer Recherche!"
 
       expect(subject).to eql(expected)
+    end
+
+    describe 'without hints' do
+      subject { Request.new(title: 'Example', text: 'Hello World!').plaintext }
     end
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -4,16 +4,34 @@ require 'rails_helper'
 
 RSpec.describe Request, type: :model do
   let(:user) { User.create! }
+  let(:request) do
+    Request.new(
+      text: 'What is the answer to life, the universe and everything?',
+      hints: ['photo', 'confidential']
+    )
+  end
+
+  describe 'hints' do
+    subject { request.hints }
+    it { should contain_exactly('photo', 'confidential') }
+  end
+
+  describe 'deliverable_message' do
+    subject { request.deliverable_message }
+    it { should include 'Hallo, die Redaktion hat eine neue Frage an dich!' }
+    it { should include 'What is the answer to life, the universe and everything?' }
+    it { should include 'Textbaustein für Foto' }
+    it { should include 'Textbaustein für vertrauliche Informationen' }
+    it { should_not include 'Textbaustein für Kontaktweitergabe' }
+  end
+
   describe '::add_reply' do
     subject { -> { Request.add_reply(answer: 'The answer is 42.', user: user) } }
     it { should_not raise_error }
     it { should_not(change { Reply.count }) }
 
     describe 'given a recent request' do
-      before(:each) do
-        Request.create!(text: 'What is the answer to life the universe and everything?')
-      end
-
+      before(:each) { request.save! }
       it { should change { Reply.count }.from(0).to(1) }
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -4,25 +4,33 @@ require 'rails_helper'
 
 RSpec.describe Request, type: :model do
   let(:user) { User.create! }
+
   let(:request) do
     Request.new(
-      text: 'What is the answer to life, the universe and everything?',
+      title: 'Hitchhiker’s Guide',
+      text: 'What is the answer to life, the universe, and everything?',
       hints: ['photo', 'confidential']
     )
   end
 
-  describe 'hints' do
-    subject { request.hints }
-    it { should contain_exactly('photo', 'confidential') }
+  subject { request }
+
+  it 'has title, text, and hints' do
+    expect(subject.attributes.keys).to include('title', 'text', 'hints')
   end
 
-  describe 'deliverable_message' do
-    subject { request.deliverable_message }
-    it { should include 'Hallo, die Redaktion hat eine neue Frage an dich!' }
-    it { should include 'What is the answer to life, the universe and everything?' }
-    it { should include 'Textbaustein für Foto' }
-    it { should include 'Textbaustein für vertrauliche Informationen' }
-    it { should_not include 'Textbaustein für Kontaktweitergabe' }
+  describe 'plaintext' do
+    subject { request.plaintext }
+
+    it 'renders correct plaintext message' do
+      expected  = "Hallo, die Redaktion hat eine neue Frage an dich:\n\n"
+      expected += "What is the answer to life, the universe, and everything?\n\n"
+      expected += "Textbaustein für Foto\n\n"
+      expected += "Textbaustein für vertrauliche Informationen\n\n"
+      expected += "Vielen Dank für deine Hilfe bei unserer Recherche!"
+
+      expect(subject).to eql(expected)
+    end
   end
 
   describe '::add_reply' do

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -5,7 +5,8 @@ require 'telegram/bot/rspec/integration/rails'
 
 RSpec.describe 'Requests', telegram_bot: :rails do
   describe 'POST /requests' do
-    subject { -> { post requests_path, params: { question: 'How do you do?' } } }
+    subject { -> { post requests_path, params: { text: 'How do you do?' } } }
+
     describe 'without users' do
       it { should_not raise_error }
       it { should change { Request.count }.from(0).to(1) }
@@ -19,7 +20,10 @@ RSpec.describe 'Requests', telegram_bot: :rails do
           'new_question_email',
           'deliver_now',
           {
-            params: { question: 'How do you do?', to: 'user@example.org' },
+            params: {
+              question: "Hallo, die Redaktion hat eine neue Frage an dich:\n\nHow do you do?\n\nVielen Dank für deine Hilfe bei unserer Recherche!",
+              to: 'user@example.org'
+            },
             args: []
           }
         )
@@ -31,7 +35,7 @@ RSpec.describe 'Requests', telegram_bot: :rails do
     describe 'given a user with a telegram_chat_id' do
       let(:chat_id) { 4711 }
       before(:each) { User.create!(telegram_chat_id: 4711, email: nil) }
-      it { should respond_with_message 'How do you do?' }
+      it { should respond_with_message "Hallo, die Redaktion hat eine neue Frage an dich:\n\nHow do you do?\n\nVielen Dank für deine Hilfe bei unserer Recherche!" }
       it { should_not have_enqueued_job.on_queue('mailers') }
     end
   end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -5,11 +5,18 @@ require 'telegram/bot/rspec/integration/rails'
 
 RSpec.describe 'Requests', telegram_bot: :rails do
   describe 'POST /requests' do
-    subject { -> { post requests_path, params: { text: 'How do you do?' } } }
+    subject { -> { post requests_path, params: params } }
+    let(:params) { { title: 'Example Question', text: 'How do you do?', hints: ['confidential'] } }
+
+    it { should change { Request.count }.from(0).to(1) }
+
+    describe 'without hints param' do
+      let(:params) { { title: 'Example Question', text: 'How do you do?' } }
+      it { should_not raise_error }
+    end
 
     describe 'without users' do
       it { should_not raise_error }
-      it { should change { Request.count }.from(0).to(1) }
     end
 
     describe 'given a user with an email address' do
@@ -21,7 +28,7 @@ RSpec.describe 'Requests', telegram_bot: :rails do
           'deliver_now',
           {
             params: {
-              question: "Hallo, die Redaktion hat eine neue Frage an dich:\n\nHow do you do?\n\nVielen Dank für deine Hilfe bei unserer Recherche!",
+              question: "Hallo, die Redaktion hat eine neue Frage an dich:\n\nHow do you do?\n\nTextbaustein für vertrauliche Informationen\n\nVielen Dank für deine Hilfe bei unserer Recherche!",
               to: 'user@example.org'
             },
             args: []
@@ -35,7 +42,7 @@ RSpec.describe 'Requests', telegram_bot: :rails do
     describe 'given a user with a telegram_chat_id' do
       let(:chat_id) { 4711 }
       before(:each) { User.create!(telegram_chat_id: 4711, email: nil) }
-      it { should respond_with_message "Hallo, die Redaktion hat eine neue Frage an dich:\n\nHow do you do?\n\nVielen Dank für deine Hilfe bei unserer Recherche!" }
+      it { should respond_with_message "Hallo, die Redaktion hat eine neue Frage an dich:\n\nHow do you do?\n\nTextbaustein für vertrauliche Informationen\n\nVielen Dank für deine Hilfe bei unserer Recherche!" }
       it { should_not have_enqueued_job.on_queue('mailers') }
     end
   end


### PR DESCRIPTION
![2020-05-18 23 11 28](https://user-images.githubusercontent.com/1512805/82260225-27628e00-995d-11ea-85c7-3c938188abb0.gif)

**UX:**
* Adds a field for an internal title.
* Adds checkboxes for a number of hints ("Hinweise/Textbausteine").
* Adds a live-preview of the message that will be sent to contributors, including hints.
* Currently, submitting the form won’t redirect you anywhere – I think we should eventually redirect to the request overview ("Übersicht für eine Recherchefrage") displaying the request and (once they come in) all replies for that request.

**Technical Details:**
* Adds a `hints` column to `requests`. This column contains an array hints ("Textbausteine") the editor selected and that should be included in the message sent to users via email or messenger.
* Adds a `plaintext` method to `Request` that generates a plaintext representation of the request using (currently) hard-coded salutation, greetings, the question text, and all hints ("Textbausteine").
* Adds a `Page` component that provides a card-like page in front of a light-gray background.
* Adds a `PageTitle` that provides a simple headline with a subtle box shadow to separate it from other page contents. (This is pretty similar to the `PageHeader` component we already use and might eventually replace it. However, I didn’t want to break existing views so I decided to add this as a separate component for now.)
* Some static strings/UI copy is duplicated in separated places. I’d like to eventually extract them to a locale file, but didn’t want to address this in this PR as it’s the case in many places across the app.