### PR TITLE
Set input font size relative to parent

### DIFF
--- a/app/components/input/input.css
+++ b/app/components/input/input.css
@@ -6,6 +6,7 @@
   width: 100%;
   padding: var(--input-padding);
 
+  font-size: inherit;
   border-radius: var(--border-radius);
   border: var(--input-border-width) solid var(--color-border);
 

--- a/app/components/nav_bar/nav_bar.css
+++ b/app/components/nav_bar/nav_bar.css
@@ -5,7 +5,7 @@
   padding: var(--spacing-unit-s) var(--spacing-unit);
   background: var(--color-blue-dark);
   color: rgba(255, 255, 255, .8);
-  font-size: .85rem;
+  font-size: var(--font-size-s);
 }
 
 .NavBar > ul {


### PR DESCRIPTION
This sets the font size of input elements depending on the parent element, resulting in a more balanced apeareance of the navigation bar.

<img width="864" alt="Screenshot 2020-05-19 01 23 04" src="https://user-images.githubusercontent.com/1512805/82268518-7f09f500-996f-11ea-877c-31e90e572675.png">
