### PR TITLE
Misc UX improvements

### DIFF
--- a/app/components/excerpt/excerpt.css
+++ b/app/components/excerpt/excerpt.css
@@ -22,3 +22,7 @@ a.Excerpt:hover .Excerpt-title {
   color: var(--color-text-light);
   margin-left: var(--spacing-unit-s);
 }
+
+.Excerpt-text {
+  color: var(--color-text-light);
+}

--- a/app/components/excerpt/excerpt.html.erb
+++ b/app/components/excerpt/excerpt.html.erb
@@ -9,7 +9,7 @@
       <%= time_ago_in_words(date) %>
     </span>
   </div>
-  <span class="Excerpt-text">
+  <p class="Excerpt-text">
     <%= text %>
-  </span>
+  </p>
 </a>

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -3,7 +3,7 @@
 class Reply < ApplicationRecord
   include PgSearch::Model
 
-  default_scope { order(:created_at) }
+  default_scope { order(created_at: :desc) }
 
   multisearchable against: :text
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -3,7 +3,7 @@
 class Request < ApplicationRecord
   has_many :replies, dependent: :destroy
   attribute :hints, :string, array: true, default: []
-  default_scope { order(:created_at) }
+  default_scope { order(created_at: :desc) }
 
   HINT_TEXTS = {
     photo: 'Textbaustein für Foto',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   multisearchable against: %i[first_name last_name username note]
   has_many :replies, dependent: :destroy
   has_many :requests, through: :replies
+  default_scope { order(:first_name, :last_name) }
 
   def self.upsert_via_telegram(message)
     from, chat = message.values_at('from', 'chat')

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <%= c 'box' do %>
-    <%= c 'stack', space: :xlarge do %>
+    <%= c 'stack' do %>
       <% @requests.each do |request| %>
         <%= c 'excerpt',
           title: request.title,

--- a/app/views/requests/show_user_messages.html.erb
+++ b/app/views/requests/show_user_messages.html.erb
@@ -3,9 +3,6 @@
     <%= I18n.t 'conversation.conversation', count: 1 %>
   <% end %>
   <%= c 'box' do %>
-    <%= c 'stack' do %>
-      <%= c 'chat', user: @user, messages: @chat_messages %>
-      <%= c 'button', label: 'Zurück', link: user_path(@user) %>
-    <% end %>
+    <%= c 'chat', user: @user, messages: @chat_messages %>
   <% end %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,8 +21,6 @@
           %>
         <% end %>
       <% end %>
-
-      <%= c 'button', label: 'Zurück zur Benutzer-Liste', link: users_path %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,7 +17,7 @@
             title: request.title,
             text: request.text,
             date: request.created_at,
-            link: request_path(request)
+            link: user_request_path(id: request.id, user_id: @user.id)
           %>
         <% end %>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,12 +12,12 @@
           <%= I18n.t 'contributor.answered_requests' %>
         <% end %>
 
-        <% @user.requests.uniq.each do |request| %>
+        <% @user.replies.each do |reply| %>
           <%= c 'excerpt',
-            title: request.title,
-            text: request.text,
-            date: request.created_at,
-            link: user_request_path(id: request.id, user_id: @user.id)
+            title: reply.request.title,
+            text: reply.text,
+            date: reply.created_at,
+            link: user_request_path(id: reply.request.id, user_id: @user.id)
           %>
         <% end %>
       <% end %>

--- a/frontend/global/variables.css
+++ b/frontend/global/variables.css
@@ -24,7 +24,7 @@
 
   --color-bg: #fff;
   --color-text: #333;
-  --color-text-light: #888;
+  --color-text-light: #666;
   --color-primary: var(--color-blue);
   --color-accent: var(--color-blue-light);
   --color-border: #ccc;

--- a/spec/models/reply_spec.rb
+++ b/spec/models/reply_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reply, type: :model do
+  it 'is by default sorted in reverse chronological order' do
+    oldest_reply = create(:reply, created_at: 2.hours.ago)
+    newest_reply = create(:reply, created_at: 1.hour.ago)
+
+    expect(described_class.first).to eq(newest_reply)
+    expect(described_class.last).to eq(oldest_reply)
+  end
+end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe Request, type: :model do
     expect(subject.attributes.keys).to include('title', 'text', 'hints')
   end
 
+  it 'is by default sorted in reverse chronological order' do
+    oldest_request = create(:request, created_at: 2.hours.ago)
+    newest_request = create(:request, created_at: 1.hour.ago)
+
+    expect(described_class.first).to eq(newest_request)
+    expect(described_class.last).to eq(oldest_request)
+  end
+
   describe '.hints' do
     subject { Request.new(title: 'Example').hints }
     it { should match_array([]) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
+RSpec.describe User, type: :model do # rubocop:disable Metrics/BlockLength
   it 'is sorted in alphabetical order' do
     zora = create(:user, first_name: 'Zora', last_name: 'Zimmermann')
     adam_zimmermann = create(:user, first_name: 'Adam', last_name: 'Zimmermann')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  it 'is sorted in alphabetical order' do
+    zora = create(:user, first_name: 'Zora', last_name: 'Zimmermann')
+    adam_zimmermann = create(:user, first_name: 'Adam', last_name: 'Zimmermann')
+    adam_ackermann = create(:user, first_name: 'Adam', last_name: 'Ackermann')
+
+    expect(User.first).to eq(adam_ackermann)
+    expect(User.second).to eq(adam_zimmermann)
+    expect(User.third).to eq(zora)
+  end
+
   describe '#name=' do
     let(:user) { User.new(first_name: 'John', last_name: 'Doe') }
     subject { -> { user.name = 'Till Prochaska' } }


### PR DESCRIPTION
* Requests and replies are now sorted in reversed chronological order. Users are sorted alphabetically (close #91).

* Replies to a request on a user’s profile page now link directly to the relevant conversation ("Nachrichtenverlauf")
   
   <img width="880" alt="Screenshot 2020-05-21 19 21 33" src="https://user-images.githubusercontent.com/1512805/82586738-587ad280-9b98-11ea-9056-6fa31b5fd169.png">

* The text in requests and replies listings now has a slightly lighter text color than the title – makes it easier to scan the list:
   
   <img width="945" alt="Screenshot 2020-05-21 19 23 49" src="https://user-images.githubusercontent.com/1512805/82587014-c6bf9500-9b98-11ea-89f1-3e7d3a657265.png">
