### PR TITLE
fix: Update telegram bot poller in production

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -62,4 +62,5 @@ rsync \
     "cd $deploy_path &&" \
     "BUNDLE_PATH=vendor/bundle bundle install --without development test &&" \
     "RAILS_ENV=production bin/rake db:prepare &&" \
-    "supervisorctl restart 100eyes"
+    "supervisorctl restart 100eyes &&" \
+    "supervisorctl restart 100eyes-telegram-bot-poller"


### PR DESCRIPTION
@tillprochaska: Ouch! That was a tough error. I was confused why I
would see my telegram photo replies added to a completely wrong request
and why no photo nor caption was visible. Turns out, the telegram bot
poller would never update during a deployment.