### PR TITLE
Update text modules (close #124, close #112)

### DIFF
--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -2,11 +2,11 @@ import { Controller } from 'stimulus';
 import sanitize from '../../../frontend/helpers/sanitize.js';
 
 const NOTE_TEXTS = {
-  photo: 'Textbaustein für Fotonutzung',
-  address: 'Textbaustein für Addressnutzung',
-  contact: 'Textbaustein für Kontaktweitergabe',
-  medicalInfo: 'Textbaustein für medizinische Informationen',
-  confidential: 'Textbaustein für vertrauliche Informationen',
+  photo: 'Schicken Sie uns doch auch ein Foto (oder mehrere). Bitte schicken Sie nur Fotos, die Sie selber gemacht haben. Mit der Zusendung von Fotos geben Sie gleichzeitig Ihr Einverständnis für eine mögliche Veröffentlichung. Bei Veröffentlichung nennen wir Sie als Urheber (Foto: Max Mustermann/100eyes).',
+  address: 'Schicken Sie uns doch eine Adresse oder genaue Koordinaten. Wir nutzen die Geodaten für unsere Recherchen und werden sie eventuell in einem Text verarbeiten oder als Datenpunkt auf einer Karte verwenden.',
+  contact: 'Schicken Sie uns gerne Kontaktdaten. Wir nutzen die Kontaktdaten für unsere Recherchen und werden die Person eventuell kontaktieren, aber keine Kontaktdaten veröffentlichen.',
+  medicalInfo: 'Sie stellen uns hier möglicherweise sensible medizinische Informationen bereit. Wir sind uns dessen bewusst und behandeln Ihre Daten mit aller gebotenen Vorsicht. Wenn Sie uns Daten schicken, helfen uns diese Informationen für unsere weiteren Recherchen. Ihre Daten werden wir nur intern auswerten, aber nicht veröffentlichen. Es sei denn, Sie geben Ihr ausdrückliches Einverständnis, nachdem wir Sie separat darum gebeten haben.',
+  confidential: 'Sie stellen uns hier möglicherweise vertrauliche Informationen bereit. Wir sind uns dessen bewusst und behandeln diese Informationen mit aller gebotenen Vorsicht. Wir werden Ihre Informationen nur intern auswerten, aber nicht ungefragt veröffentlichen.',
 };
 
 const template = ({ message, notes }) => {
@@ -16,8 +16,8 @@ const template = ({ message, notes }) => {
     .filter(([key, isActive]) => isActive)
     .map(([key]) => NOTE_TEXTS[key]);
 
-  const intro = 'Hallo, die Redaktion hat eine neue Frage an dich:';
-  const outro = 'Vielen Dank für deine Hilfe bei unserer Recherche!';
+  const intro = 'Hallo, die Redaktion hat eine neue Frage an Sie:';
+  const outro = 'Vielen Dank für Ihre Hilfe bei unserer Recherche!';
 
   return [intro, message, ...notes, outro].join('\n\n');
 };

--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -1,12 +1,17 @@
 import { Controller } from 'stimulus';
 import sanitize from '../../../frontend/helpers/sanitize.js';
 
-const NOTE_TEXTS = {
-  photo: 'Schicken Sie uns doch auch ein Foto (oder mehrere). Bitte schicken Sie nur Fotos, die Sie selber gemacht haben. Mit der Zusendung von Fotos geben Sie gleichzeitig Ihr Einverständnis für eine mögliche Veröffentlichung. Bei Veröffentlichung nennen wir Sie als Urheber (Foto: Max Mustermann/100eyes).',
-  address: 'Schicken Sie uns doch eine Adresse oder genaue Koordinaten. Wir nutzen die Geodaten für unsere Recherchen und werden sie eventuell in einem Text verarbeiten oder als Datenpunkt auf einer Karte verwenden.',
-  contact: 'Schicken Sie uns gerne Kontaktdaten. Wir nutzen die Kontaktdaten für unsere Recherchen und werden die Person eventuell kontaktieren, aber keine Kontaktdaten veröffentlichen.',
-  medicalInfo: 'Sie stellen uns hier möglicherweise sensible medizinische Informationen bereit. Wir sind uns dessen bewusst und behandeln Ihre Daten mit aller gebotenen Vorsicht. Wenn Sie uns Daten schicken, helfen uns diese Informationen für unsere weiteren Recherchen. Ihre Daten werden wir nur intern auswerten, aber nicht veröffentlichen. Es sei denn, Sie geben Ihr ausdrückliches Einverständnis, nachdem wir Sie separat darum gebeten haben.',
-  confidential: 'Sie stellen uns hier möglicherweise vertrauliche Informationen bereit. Wir sind uns dessen bewusst und behandeln diese Informationen mit aller gebotenen Vorsicht. Wir werden Ihre Informationen nur intern auswerten, aber nicht ungefragt veröffentlichen.',
+const HINT_TEXTS = {
+  photo:
+    'Schicken Sie uns doch auch ein Foto (oder mehrere). Bitte schicken Sie nur Fotos, die Sie selber gemacht haben. Mit der Zusendung von Fotos geben Sie gleichzeitig Ihr Einverständnis für eine mögliche Veröffentlichung. Bei Veröffentlichung nennen wir Sie als Urheber (Foto: Max Mustermann/100eyes).',
+  address:
+    'Schicken Sie uns doch eine Adresse oder genaue Koordinaten. Wir nutzen die Geodaten für unsere Recherchen und werden sie eventuell in einem Text verarbeiten oder als Datenpunkt auf einer Karte verwenden.',
+  contact:
+    'Schicken Sie uns gerne Kontaktdaten. Wir nutzen die Kontaktdaten für unsere Recherchen und werden die Person eventuell kontaktieren, aber keine Kontaktdaten veröffentlichen.',
+  medicalInfo:
+    'Sie stellen uns hier möglicherweise sensible medizinische Informationen bereit. Wir sind uns dessen bewusst und behandeln Ihre Daten mit aller gebotenen Vorsicht. Wenn Sie uns Daten schicken, helfen uns diese Informationen für unsere weiteren Recherchen. Ihre Daten werden wir nur intern auswerten, aber nicht veröffentlichen. Es sei denn, Sie geben Ihr ausdrückliches Einverständnis, nachdem wir Sie separat darum gebeten haben.',
+  confidential:
+    'Sie stellen uns hier möglicherweise vertrauliche Informationen bereit. Wir sind uns dessen bewusst und behandeln diese Informationen mit aller gebotenen Vorsicht. Wir werden Ihre Informationen nur intern auswerten, aber nicht ungefragt veröffentlichen.',
 };
 
 const template = ({ message, notes }) => {
@@ -14,7 +19,7 @@ const template = ({ message, notes }) => {
 
   notes = Object.entries(notes)
     .filter(([key, isActive]) => isActive)
-    .map(([key]) => NOTE_TEXTS[key]);
+    .map(([key]) => HINT_TEXTS[key]);
 
   const intro = 'Hallo, die Redaktion hat eine neue Frage an Sie:';
   const outro = 'Vielen Dank für Ihre Hilfe bei unserer Recherche!';

--- a/app/components/request_form/request_form.rb
+++ b/app/components/request_form/request_form.rb
@@ -3,11 +3,11 @@
 module RequestForm
   class RequestForm < ApplicationComponent
     HINTS = {
-      photo: 'Fotos',
-      address: 'Adressen',
-      contact: 'Kontaktdaten',
-      medicalInfo: 'Medizinische Informationen',
-      confidential: 'Vertrauliche Informationen'
+      photo: (I18n.t 'request.hints.photo.label'),
+      address: (I18n.t 'request.hints.address.label'),
+      contact: (I18n.t 'request.hints.contact.label'),
+      medicalInfo: (I18n.t 'request.hints.medicalInfo.label'),
+      confidential: (I18n.t 'request.hints.confidential.label')
     }.freeze
 
     def initialize(request:)

--- a/app/mailers/question_mailer.rb
+++ b/app/mailers/question_mailer.rb
@@ -4,7 +4,7 @@ class QuestionMailer < ApplicationMailer
   def new_question_email
     mail(
       to: params[:to],
-      subject: 'Die Redaktion hat eine neue Frage an dich',
+      subject: 'Die Redaktion hat eine neue Frage an Sie',
       body: params[:question]
     )
   end

--- a/app/mailers/reply_mailer.rb
+++ b/app/mailers/reply_mailer.rb
@@ -4,9 +4,9 @@ class ReplyMailer < ApplicationMailer
   def user_not_found_email
     mail(
       to: params[:email],
-      subject: 'Wir können deine E-Mail Adresse nicht zuordnen',
+      subject: 'Wir können Ihre E-Mail Adresse nicht zuordnen',
       body: <<-BODY
-        Wir können deine E-Mail Adresse #{params[:email]} leider keinem
+        Wir können Ihre E-Mail Adresse #{params[:email]} leider keinem
         unserer Benutzerprofile zuordnen.
       BODY
     )

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -12,19 +12,19 @@ class Request < ApplicationRecord
   end
 
   HINT_TEXTS = {
-    photo: 'Textbaustein für Foto',
-    address: 'Textbaustein für Adressweitergabe',
-    contact: 'Textbaustein für Kontaktweitergabe',
-    medicalInfo: 'Textbaustein für medizinische Informationen',
-    confidential: 'Textbaustein für vertrauliche Informationen'
+    photo: 'Schicken Sie uns doch auch ein Foto (oder mehrere). Bitte schicken Sie nur Fotos, die Sie selber gemacht haben. Mit der Zusendung von Fotos geben Sie gleichzeitig Ihr Einverständnis für eine mögliche Veröffentlichung. Bei Veröffentlichung nennen wir Sie als Urheber (Foto: Max Mustermann/100eyes).',
+    address: 'Schicken Sie uns doch eine Adresse oder genaue Koordinaten. Wir nutzen die Geodaten für unsere Recherchen und werden sie eventuell in einem Text verarbeiten oder als Datenpunkt auf einer Karte verwenden.',
+    contact: 'Schicken Sie uns gerne Kontaktdaten. Wir nutzen die Kontaktdaten für unsere Recherchen und werden die Person eventuell kontaktieren, aber keine Kontaktdaten veröffentlichen.',
+    medicalInfo: 'Sie stellen uns hier möglicherweise sensible medizinische Informationen bereit. Wir sind uns dessen bewusst und behandeln Ihre Daten mit aller gebotenen Vorsicht. Wenn Sie uns Daten schicken, helfen uns diese Informationen für unsere weiteren Recherchen. Ihre Daten werden wir nur intern auswerten, aber nicht veröffentlichen. Es sei denn, Sie geben Ihr ausdrückliches Einverständnis, nachdem wir Sie separat darum gebeten haben.',
+    confidential: 'Sie stellen uns hier möglicherweise vertrauliche Informationen bereit. Wir sind uns dessen bewusst und behandeln diese Informationen mit aller gebotenen Vorsicht. Wir werden Ihre Informationen nur intern auswerten, aber nicht ungefragt veröffentlichen.'
   }.freeze
 
   def plaintext
     parts = []
-    parts << 'Hallo, die Redaktion hat eine neue Frage an dich:'
+    parts << 'Hallo, die Redaktion hat eine neue Frage an Sie:'
     parts << text
     parts += hints.map { |hint| HINT_TEXTS[hint.to_sym] }
-    parts << 'Vielen Dank für deine Hilfe bei unserer Recherche!'
+    parts << 'Vielen Dank für Ihre Hilfe bei unserer Recherche!'
     parts.join("\n\n")
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -12,11 +12,11 @@ class Request < ApplicationRecord
   end
 
   HINT_TEXTS = {
-    photo: 'Schicken Sie uns doch auch ein Foto (oder mehrere). Bitte schicken Sie nur Fotos, die Sie selber gemacht haben. Mit der Zusendung von Fotos geben Sie gleichzeitig Ihr Einverständnis für eine mögliche Veröffentlichung. Bei Veröffentlichung nennen wir Sie als Urheber (Foto: Max Mustermann/100eyes).',
-    address: 'Schicken Sie uns doch eine Adresse oder genaue Koordinaten. Wir nutzen die Geodaten für unsere Recherchen und werden sie eventuell in einem Text verarbeiten oder als Datenpunkt auf einer Karte verwenden.',
-    contact: 'Schicken Sie uns gerne Kontaktdaten. Wir nutzen die Kontaktdaten für unsere Recherchen und werden die Person eventuell kontaktieren, aber keine Kontaktdaten veröffentlichen.',
-    medicalInfo: 'Sie stellen uns hier möglicherweise sensible medizinische Informationen bereit. Wir sind uns dessen bewusst und behandeln Ihre Daten mit aller gebotenen Vorsicht. Wenn Sie uns Daten schicken, helfen uns diese Informationen für unsere weiteren Recherchen. Ihre Daten werden wir nur intern auswerten, aber nicht veröffentlichen. Es sei denn, Sie geben Ihr ausdrückliches Einverständnis, nachdem wir Sie separat darum gebeten haben.',
-    confidential: 'Sie stellen uns hier möglicherweise vertrauliche Informationen bereit. Wir sind uns dessen bewusst und behandeln diese Informationen mit aller gebotenen Vorsicht. Wir werden Ihre Informationen nur intern auswerten, aber nicht ungefragt veröffentlichen.'
+    photo: (I18n.t 'request.hints.photo.text'),
+    address: (I18n.t 'request.hints.address.text'),
+    contact: (I18n.t 'request.hints.contact.text'),
+    medicalInfo: (I18n.t 'request.hints.medicalInfo.text'),
+    confidential: (I18n.t 'request.hints.confidential.text')
   }.freeze
 
   def plaintext

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,6 +38,44 @@ de:
     send: Frage an alle Lokalexpert*innen senden
     success: Deine Frage wurde erfolgreich an alle Lokalexpert*innen gesendet
     replies: Alle Antworten
+    hints:
+      photo:
+        label: Fotos
+        text: >
+          Schicken Sie uns doch auch ein Foto (oder mehrere). Bitte schicken Sie
+          nur Fotos, die Sie selber gemacht haben. Mit der Zusendung von Fotos
+          geben Sie gleichzeitig Ihr Einverständnis für eine mögliche
+          Veröffentlichung. Bei Veröffentlichung nennen wir Sie als Urheber
+          (Foto: Max Mustermann/100eyes).
+      address:
+        label: Adressen
+        text: >
+          Schicken Sie uns doch eine Adresse oder genaue Koordinaten. Wir nutzen
+          die Geodaten für unsere Recherchen und werden sie eventuell in einem
+          Text verarbeiten oder als Datenpunkt auf einer Karte verwenden.
+      contact:
+        label: Kontaktdaten
+        text: >
+          Schicken Sie uns gerne Kontaktdaten. Wir nutzen die Kontaktdaten für
+          unsere Recherchen und werden die Person eventuell kontaktieren, aber
+          keine Kontaktdaten veröffentlichen.
+      medicalInfo:
+        label: Medizinische Informationen
+        text: >
+          Sie stellen uns hier möglicherweise sensible medizinische
+          Informationen bereit. Wir sind uns dessen bewusst und behandeln Ihre
+          Daten mit aller gebotenen Vorsicht. Wenn Sie uns Daten schicken,
+          helfen uns diese Informationen für unsere weiteren Recherchen. Ihre
+          Daten werden wir nur intern auswerten, aber nicht veröffentlichen. Es
+          sei denn, Sie geben Ihr ausdrückliches Einverständnis, nachdem wir Sie
+          separat darum gebeten haben.
+      confidential:
+        label: Vertrauliche Informationen
+        text: >
+          Sie stellen uns hier möglicherweise vertrauliche Informationen bereit.
+          Wir sind uns dessen bewusst und behandeln diese Informationen mit
+          aller gebotenen Vorsicht. Wir werden Ihre Informationen nur intern
+          auswerten, aber nicht ungefragt veröffentlichen.
     form:
       preview: Diese Nachricht erhalten die Lokalexpert*innen
       title:

--- a/spec/mailers/question_mailer_spec.rb
+++ b/spec/mailers/question_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe QuestionMailer, type: :mailer do
 
   describe 'subject' do
     subject { mail.subject }
-    it { should eq('Die Redaktion hat eine neue Frage an dich') }
+    it { should eq('Die Redaktion hat eine neue Frage an Sie') }
   end
 
   describe 'to' do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe Request, type: :model do
     subject { request.plaintext }
 
     it 'returns correct plaintext message' do
-      expected  = "Hallo, die Redaktion hat eine neue Frage an dich:\n\n"
+      expected  = "Hallo, die Redaktion hat eine neue Frage an Sie:\n\n"
       expected += "What is the answer to life, the universe, and everything?\n\n"
-      expected += "Textbaustein für Foto\n\n"
-      expected += "Textbaustein für vertrauliche Informationen\n\n"
-      expected += 'Vielen Dank für deine Hilfe bei unserer Recherche!'
+      expected += "#{I18n.t 'request.hints.photo.text'}\n\n"
+      expected += "#{I18n.t 'request.hints.confidential.text'}\n\n"
+      expected += 'Vielen Dank für Ihre Hilfe bei unserer Recherche!'
 
       expect(subject).to eql(expected)
     end
@@ -49,9 +49,9 @@ RSpec.describe Request, type: :model do
       subject { Request.new(title: 'Example', text: 'Hello World!', hints: []).plaintext }
 
       it 'returns correct plaintext message' do
-        expected  = "Hallo, die Redaktion hat eine neue Frage an dich:\n\n"
+        expected  = "Hallo, die Redaktion hat eine neue Frage an Sie:\n\n"
         expected += "Hello World!\n\n"
-        expected += 'Vielen Dank für deine Hilfe bei unserer Recherche!'
+        expected += 'Vielen Dank für Ihre Hilfe bei unserer Recherche!'
 
         expect(subject).to eql(expected)
       end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe 'Requests', telegram_bot: :rails do
           'deliver_now',
           {
             params: {
-              question: ['Hallo, die Redaktion hat eine neue Frage an dich:',
+              question: ['Hallo, die Redaktion hat eine neue Frage an Sie:',
                          'How do you do?',
-                         'Textbaustein für vertrauliche Informationen',
-                         'Vielen Dank für deine Hilfe bei unserer Recherche!'].join("\n\n"),
+                         I18n.t('request.hints.confidential.text'),
+                         'Vielen Dank für Ihre Hilfe bei unserer Recherche!'].join("\n\n"),
               to: 'user@example.org'
             },
             args: []
@@ -57,10 +57,10 @@ RSpec.describe 'Requests', telegram_bot: :rails do
       let(:chat_id) { 4711 }
       let(:expected_message) do
         [
-          'Hallo, die Redaktion hat eine neue Frage an dich:',
+          'Hallo, die Redaktion hat eine neue Frage an Sie:',
           'How do you do?',
-          'Textbaustein für vertrauliche Informationen',
-          'Vielen Dank für deine Hilfe bei unserer Recherche!'
+          I18n.t('request.hints.confidential.text'),
+          'Vielen Dank für Ihre Hilfe bei unserer Recherche!'
         ].join("\n\n")
       end
       before(:each) { User.create!(telegram_chat_id: 4711, email: nil) }


### PR DESCRIPTION
<img width="925" alt="Screenshot 2020-05-28 15 39 52" src="https://user-images.githubusercontent.com/1512805/83148642-8365a900-a0f9-11ea-9b6e-1e0b7d84273f.png">

@roschaefer: I’m not 100% happy with the changes I did in oder to unify the text modules for the preview in `request_form.js` and the backend `request.rb` – so this is just a quick update so we have the updated text modules for the user test.