### PR TITLE
Add additional data fields to users

### DIFF
--- a/app/components/field/field.rb
+++ b/app/components/field/field.rb
@@ -16,7 +16,7 @@ module Field
     def input_defaults
       basic_defaults
         .merge({
-                 placeholder: I18n.t("#{type}.form.#{id}.placeholder", value: value),
+                 placeholder: I18n.t("#{type}.form.#{id}.placeholder", value: value, default: nil),
                  title: I18n.t("#{type}.form.#{id}.title", value: value, default: nil),
                  styles: [:small]
                })

--- a/app/components/user_form/user_form.html.erb
+++ b/app/components/user_form/user_form.html.erb
@@ -4,12 +4,28 @@
       <%= c 'input', field.input_defaults %>
     <% end %>
 
+    <%= c 'field', object: user, id: :phone, styles: [:horizontal] do |field| %>
+      <%= c 'input', field.input_defaults.merge(type: :phone) %>
+    <% end %>
+
     <%= c 'field', object: user, id: :email, styles: [:horizontal] do |field| %>
       <%= c 'input', field.input_defaults %>
     <% end %>
 
     <%= c 'field', object: user, id: :username, styles: [:horizontal] do |field | %>
       <%= c 'input', field.input_defaults.merge(disabled: true) %>
+    <% end %>
+
+    <%= c 'field', object: user, id: :street, styles: [:horizontal] do |field | %>
+      <%= c 'input', field.input_defaults %>
+    <% end %>
+
+    <%= c 'field', object: user, id: :zip_code, styles: [:horizontal] do |field | %>
+      <%= c 'input', field.input_defaults %>
+    <% end %>
+
+    <%= c 'field', object: user, id: :city, styles: [:horizontal] do |field | %>
+      <%= c 'input', field.input_defaults %>
     <% end %>
 
     <%= c 'field', object: user, id: :note, styles: [:horizontal] do |field| %>

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,7 +52,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:note, :name, :email)
+    params.require(:user).permit(:note, :name, :email, :phone, :street, :zip_code, :city)
   end
 
   def message_params

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -47,6 +47,8 @@ de:
       name:
         label: Name
         placeholder: Vor- und Nachname
+      phone:
+        label: Telefon
       email:
         label: E-Mail-Adresse
         placeholder: Keine E-Mail-Adresse hinterlegt
@@ -54,6 +56,12 @@ de:
         label: Telegram
         placeholder: Kein Telegram-Nutzername hinterlegt
         title: Du kannst den Nutzernamen nicht selbst ändern. Sobald %{value} das erste Mal via Telegram interagiert, erscheint hier der Nutzername.
+      street:
+        label: Straße
+      zip_code:
+        label: Postleitzahl
+      city:
+        label: Stadt
       note:
         label: Notiz
         placeholder: Klicke hier, um eine Notiz zu %{value} zu hinterlegen

--- a/db/migrate/20200614220817_add_additional_fields_to_users.rb
+++ b/db/migrate/20200614220817_add_additional_fields_to_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAdditionalFieldsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :street
+      t.string :zip_code
+      t.string :city
+      t.string :phone
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_13_115522) do
+ActiveRecord::Schema.define(version: 2020_06_14_220817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -100,6 +100,10 @@ ActiveRecord::Schema.define(version: 2020_06_13_115522) do
     t.integer "telegram_id"
     t.string "avatar_url"
     t.string "note"
+    t.string "street"
+    t.string "zip_code"
+    t.string "city"
+    t.string "phone"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["telegram_chat_id"], name: "index_users_on_telegram_chat_id", unique: true
     t.index ["telegram_id"], name: "index_users_on_telegram_id", unique: true

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -29,7 +29,18 @@ RSpec.describe '/users', type: :request do
   end
 
   describe 'PATCH /update' do
-    let(:new_attrs) { { name: 'Zora Zimmermann', note: '11 Jahre alt', email: 'zora@example.org' } }
+    let(:new_attrs) do
+      {
+        name: 'Zora Zimmermann',
+        phone: '012345678',
+        street: 'Musterstraße 123',
+        zip_code: '12345',
+        city: 'Musterstadt',
+        note: '11 Jahre alt',
+        email: 'zora@example.org'
+      }
+    end
+
     subject { -> { patch user_url(user), params: { user: new_attrs }, headers: auth_headers } }
 
     it 'updates the requested user' do
@@ -38,6 +49,10 @@ RSpec.describe '/users', type: :request do
 
       expect(user.first_name).to eq('Zora')
       expect(user.last_name).to eq('Zimmermann')
+      expect(user.phone).to eq('012345678')
+      expect(user.street).to eq('Musterstraße 123')
+      expect(user.zip_code).to eq('12345')
+      expect(user.city).to eq('Musterstadt')
       expect(user.note).to eq('11 Jahre alt')
       expect(user.email).to eq('zora@example.org')
     end


### PR DESCRIPTION
Not the best UX (e.g. usually you’d want to have zip and city inputs in a single line). Works for now though.

<img width="921" alt="Screenshot 2020-06-15 00 14 12" src="https://user-images.githubusercontent.com/1512805/84605675-6245dc00-ae9f-11ea-9fd7-6b81e297f864.png">


Close #186 