### PR TITLE
fix: Blocked Telegram messages are marked but saved

### DIFF
--- a/app/components/chat_message/chat_message.css
+++ b/app/components/chat_message/chat_message.css
@@ -37,6 +37,8 @@
   display: block;
 }
 
-.ChatMessage-unknownContent {
+.ChatMessage-warnings {
+  display: flex;
+  flex-direction: column;
   color: var(--color-red);
 }

--- a/app/components/chat_message/chat_message.html.erb
+++ b/app/components/chat_message/chat_message.html.erb
@@ -25,10 +25,14 @@
     <div class="ChatMessage-meta">
       <a href="#<%= id %>"><%= date_time(message.created_at) %></a>
 
-      <% if unknown_content? %>
-        <div class="ChatMessage-unknownContent">
-          <%= c 'icon', icon: 't-warning', styles: [:inline] %>
-          <%= t 'components.chat_message.contains_unknown_content' %>
+      <% if warnings.any? %>
+        <div class="ChatMessage-warnings">
+          <% warnings.each do |warning| %>
+            <span>
+              <%= c 'icon', icon: 't-warning', styles: [:inline] %>
+              <%= warning %>
+            </span>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/components/chat_message/chat_message.rb
+++ b/app/components/chat_message/chat_message.rb
@@ -17,8 +17,11 @@ module ChatMessage
       message.photos
     end
 
-    def unknown_content?
-      message.unknown_content?
+    def warnings
+      warnings = []
+      warnings << I18n.t('components.chat_message.contains_unknown_content') if message.unknown_content
+      warnings << I18n.t('components.chat_message.blocked_by_user') if message.blocked
+      warnings
     end
 
     attr_reader :message

--- a/config/environments/common/production.rb
+++ b/config/environments/common/production.rb
@@ -105,7 +105,6 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # CUSTOM
-  config.bot_id = (ENV['BOT'] || :default).to_sym
   config.action_mailer.smtp_settings = {
     user_name: Rails.application.credentials.sendgrid[:user],
     password: Rails.application.credentials.sendgrid[:password],

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # CUSTOM
-  config.bot_id = (ENV['BOT'] || :default).to_sym
   config.mailer = {
     from: '100eyes-development-account@example.org'
   }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,7 +55,6 @@ Rails.application.configure do
   #
   config.active_job.queue_adapter = :test
 
-  config.bot_id = (ENV['BOT'] || :default).to_sym
   config.mailer = {
     from: '100eyes-test-account@example.org'
   }

--- a/config/initializers/telegram_initializer.rb
+++ b/config/initializers/telegram_initializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   config.bot_id = (ENV['BOT'] || :default).to_sym
 end

--- a/config/initializers/telegram_initializer.rb
+++ b/config/initializers/telegram_initializer.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.bot_id = (ENV['BOT'] || :default).to_sym
+end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,6 +7,7 @@ de:
     chat_message:
       expand: weiterlesen
       contains_unknown_content: Enthält nicht unterstützte Inhalte
+      blocked_by_user: Wurde von der Lokalexpert*in blockiert
     chat_messages_group:
       reply: nachfragen
     chat_form:

--- a/db/migrate/20200613115522_add_blocked_flag_to_messages.rb
+++ b/db/migrate/20200613115522_add_blocked_flag_to_messages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBlockedFlagToMessages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :messages, :blocked, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_212833) do
+ActiveRecord::Schema.define(version: 2020_06_13_115522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_06_12_212833) do
     t.bigint "recipient_id"
     t.boolean "broadcasted", default: false
     t.boolean "unknown_content", default: false
+    t.boolean "blocked", default: false
     t.index ["recipient_id"], name: "index_messages_on_recipient_id"
     t.index ["request_id"], name: "index_messages_on_request_id"
     t.index ["sender_id"], name: "index_messages_on_sender_id"

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -134,6 +134,21 @@ RSpec.describe Message, type: :model do
     end
   end
 
+  describe '#before_create' do
+    let(:message) { create(:message, sender: nil, recipient: recipient) }
+    describe 'given a recipient with telegram' do
+      let(:recipient) { create(:user, telegram_chat_id: 47, telegram_id: 11) }
+      describe '#blocked' do
+        subject { message.blocked }
+        it { should be(false) }
+        describe 'but if user blocked the telegram bot' do
+          before(:each) { allow(Telegram.bots[Rails.configuration.bot_id]).to receive(:send_message).and_raise(Telegram::Bot::Forbidden) }
+          it { should be(true) }
+        end
+      end
+    end
+  end
+
   let(:telegram_message_with_photo) do
     {
       'message_id' => 186,


### PR DESCRIPTION
fix: Blocked Telegram messages are marked but saved

This will avoid HTTP 500 error and unexpected behaviour

fix #199


![Screenshot - 2020-06-13T142237 328](https://user-images.githubusercontent.com/2110676/84568617-e0f82780-ad80-11ea-992c-545056b7ff6a.png)


@tillprochaska please change target branch of this PR when you merge #196 
