### PR TITLE
feat: Validate backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-debug.log*
 .yarn-integrity
 
 vendor/bundle
+
+backups/

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,7 +26,7 @@ default: &default
 
 development:
   <<: *default
-  database: app_development
+  database: <%= ENV["APP_DATABASE_NAME"] || 'app_development' %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ x-defaults: &x-defaults
     APP_DATABASE_HOST: db
     APP_DATABASE_USERNAME: postgres
     APP_DATABASE_PASSWORD: postgres
+    APP_DATABASE_NAME: "${APP_DATABASE_NAME:-app_development}"
     MAILSERVER_HOST: mailserver
     MAILSERVER_PORT: 25
     WEBPACKER_DEV_SERVER_HOST: webpack
@@ -44,7 +45,7 @@ services:
   db:
     image: postgres:12.2-alpine
     environment:
-      POSTGRES_DB: app_development
+      POSTGRES_DB: "${APP_DATABASE_NAME:-app_development}"
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres_data:/var/lib/postgresql/data


### PR DESCRIPTION
OK, so how do we do manual backups? From my perspective, there are two
things we need to backup:

* database
* storage/ folder

**Strategy:**

When you ssh into our production server, you can do the following:

```
pg_dump -d PRODUCTION_DATABASE > ~/backups/DATE/PRODUCTION_DATABASE.dump
cp -r 100eyes/storage/ backups/DATE/
```

Then log out and copy the files locally:

```
scp -r USER@SERVER:~/backups/DATE ./backups
```

Restore:

```
rm -rf storage/*
cp -r backups/DATE/storage ./storage
docker-compose run --rm app createdb PRODUCTION_DATABASE
docker-compose run --rm app psql -h db -U postgres app_production < backups/DATE/PRODUCTION_DATABASE.dump
```

Double-check the data could be restored:

```
BOT=robert APP_DATABASE_NAME=PRODUCTION_DATABASE docker-compose up app
```

The `up app` is important to avoid starting the telegram bot. Otherwise
this could lead to a locally running bot poller which consumes API messages
that were meant for the poller in production.