### PR TITLE
Revert pg_search as it introduces a reported bug.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,9 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'sucker_punch', '~> 2.1'
 gem 'telegram-bot'
 
-gem 'pg_search', '~> 2.3'
+# FIXME: version 2.3.3 introduced a bug, found https://github.com/Casecommons/pg_search/issues/446.
+# Add back pessimistic operator after resolved.
+gem 'pg_search', '2.3.2'
 
 gem 'valid_email2', '~> 3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     parser (2.7.1.4)
       ast (~> 2.4.1)
     pg (1.2.3)
-    pg_search (2.3.3)
+    pg_search (2.3.2)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     pry (0.13.0)
@@ -295,7 +295,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.3)
   mini_magick (~> 4.10)
   pg (>= 0.18, < 2.0)
-  pg_search (~> 2.3)
+  pg_search (= 2.3.2)
   pry-rails
   puma (~> 5.0)
   rack-attack (~> 6.3)


### PR DESCRIPTION
- See https://github.com/Casecommons/pg_search/issues/446

Have created an issue https://github.com/tactilenews/100eyes/issues/385, which this `PR` doesn't address, but we discussed waiting to see what happens with the `pg_search` issue :point_up: and worrying about upgrading or helping to get to the bottom of the error later.