### PR TITLE
Allow any Ruby 2.7.x version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '~> 2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3'


### PR DESCRIPTION
Background: Out hosting provider maintains installed Ruby version and installs patch versions shortly after they are released. This is good for as, as e.g. important security patches are installed for us.

However, it may leed to (and has led to) issues, as bundler checks for the installed ruby version when running `bundle exec` and fails if it is not available.

As generally patch versions are backwards compatible, it’s safe to use this slightly more pessimistic version constraint in this case.