### PR TITLE
Fix misc visual bugs

### DIFF
--- a/app/components/card/card.css
+++ b/app/components/card/card.css
@@ -4,4 +4,10 @@
   width: 100%;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 2px 20px rgba(0, 0, 0, 0.1);
   border-radius: var(--border-radius);
+  transition: 0.15s all ease-in-out;
+}
+
+a .Card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 5px 20px rgba(0, 0, 0, 0.2);
 }

--- a/app/components/chat_message_photos/chat_message_photos.css
+++ b/app/components/chat_message_photos/chat_message_photos.css
@@ -1,6 +1,6 @@
 .ChatMessagePhotos {
   display: grid;
-  padding: var(--spacing-unit-s) 0;
+  padding: var(--spacing-unit-xs) 0;
   gap: var(--spacing-unit-xs);
 
   /*

--- a/app/components/plaintext_message/plaintext_message.rb
+++ b/app/components/plaintext_message/plaintext_message.rb
@@ -17,7 +17,7 @@ module PlaintextMessage
     attr_reader :message
 
     def content
-      message || @content
+      (message || @content || '').strip
     end
   end
 end

--- a/app/components/request_row/request_row.html.erb
+++ b/app/components/request_row/request_row.html.erb
@@ -1,7 +1,7 @@
 <article class="<%= class_attr %>">
   <%= link_to request_path(id: request.id) do %>
     <%= c 'card' do %>
-      <%= c 'box', style: :card do %>
+      <%= c 'box' do %>
         <%= c 'stack', space: :small do %>
 
           <%= c 'stack', space: :xsmall do %>

--- a/spec/components/plaintext_message_spec.rb
+++ b/spec/components/plaintext_message_spec.rb
@@ -5,6 +5,30 @@ require 'rails_helper'
 RSpec.describe PlaintextMessage::PlaintextMessage, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
-  let(:params) { { message: 'Hello World!' } }
+  let(:params) { { message: message } }
+  let(:message) { 'Hello World!' }
   it { should have_css('.PlaintextMessage') }
+
+  describe 'given a message with leading/tailing whitespace' do
+    let(:message) do
+      <<~MESSAGE
+
+        Hello World!
+
+      MESSAGE
+    end
+
+    it 'strips whitespace' do
+      expect(subject.child.inner_html).to eq('Hello World!')
+    end
+  end
+
+  describe 'given a nil message' do
+    let(:message) { nil }
+
+    it 'renders successfully' do
+      expect(subject).to have_css('.PlaintextMessage')
+      expect(subject.child.inner_html).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes/solves three small UI-related problems:

For messages that contain photos, but no text, whitespace around the thumbnails is now more balanced (close #326):

<img width="326" alt="Screen Shot 2020-10-10 at 14 53 47" src="https://user-images.githubusercontent.com/1512805/95656964-feac8200-0b11-11eb-9129-d3c71ccb6732.png">

Leading/tailing newlines in messages are now stripped. This was a problem especially with replies parsed from emails, as some mail clients tend to add additional HTML markup which would result in additional whitespace (close #329).

<img width="402" alt="Screen Shot 2020-10-10 at 15 48 28" src="https://user-images.githubusercontent.com/1512805/95656989-2ac80300-0b12-11eb-8269-2b568a285518.png">

Clickable/linked card components now have a hover effect (e.g. in requests#index) (close #255).

![Screen Recording 2020-10-10 at 16 00 53](https://user-images.githubusercontent.com/1512805/95656999-4a5f2b80-0b12-11eb-933a-dda54ad8c378.gif)
