### PR TITLE
Add health endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -4,6 +4,11 @@ class HealthController < ApplicationController
   skip_before_action :authenticate
 
   def index
+    ActiveRecord::Base.connection.execute('select 1')
+    ActiveRecord::Migration.check_pending!
+  rescue StandardError
+    render status: :service_unavailable, json: { status: 'Service Unavailable' }
+  else
     render json: { status: 'OK' }
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HealthController < ApplicationController
+  skip_before_action :authenticate
+
   def index
     render json: { status: 'OK' }
   end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class HealthController < ApplicationController
+  def index
+    render json: { status: 'OK' }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   root to: redirect('/dashboard')
   get '/dashboard', to: 'dashboard#index'
   get '/search', to: 'search#index'
+  get '/health', to: 'health#index'
+
   telegram_webhook Telegram::WebhookController, Rails.configuration.bot_id
 
   resources :requests, only: %i[index show new create] do


### PR DESCRIPTION
Closes #364.

This adds a simple `/health` route for use with our monitoring provider (and for that purpose skips authentication). This route simply returns a 200 status code if everything is good – in case there are database related errors (a bad connection, pending migreations), Rails will always send an error response. In cases where the app isn’t running at all, obviously, the request will be unsuccessful as well.