### PR TITLE
Fix wording in onboarding flow

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -67,7 +67,7 @@ de:
         - icon: app-services
           text: Werte die Antworten mit Hilfe von 100eyes aus und komponiere deine Veröffentlichung.
     onboarding_header:
-      byline: eine Dialogrecherche von <a class="Link" href="https://tactile.news" target="_blank">tactile.news</a>
+      byline: eine Dialog-Recherche von <a class="Link" href="https://tactile.news" target="_blank">tactile.news</a>
     onboarding_instructions:
       email:
         label: E-Mail
@@ -83,10 +83,10 @@ de:
           - Wenn Sie den @%{username} bei Telegram gefunden haben, klicken Sie auf „Start”.
           - Senden Sie uns eine erste Nachricht mit Ihrem vollen Namen.
     onboarding_success:
-      heading: Danke für deine Anmeldung zu %{project_name}!
+      heading: Danke für Ihre Anmeldung zu %{project_name}!
       text: |
-        Unsere Dialog-Recherche startet am <strong>am 21.12.2021</strong>.<br>
-        Wir melden uns dann wieder bei dir.
+        Unsere Dialog-Recherche startet bald.<br>
+        Wir melden uns dann wieder bei Ihnen.
     onboarding_footer:
       imprint: Impressum
 
@@ -226,23 +226,23 @@ de:
     unknown_content_message: |
       Unsere Software kann derzeit Textnachrichten und Bilder verarbeiten, jedoch noch keine weiteren Inhalte wie z.B. Sprachnachrichten oder Dateianhänge. Für die Zwischenzeit bitten wir dich, Nachrichten mit solchen Inhalten an @FrauCsu (Astrid Csuraji) zu schicken. Vielen Dank!
     welcome_message: |
-      Herzlich Willkommen bei #50survivors. Danke, dass Du an unserer Dialogrecherche teilnimmst. In den kommenden Wochen nutzen wir Telegram für den Austausch. Ein Bot arbeitet wie ein Postbote für uns und stellt Fragen und Antworten zu. Deine Nachrichten lesen und beantworten wir aber selbstverständlich persönlich. Wir freuen uns sehr auf den Dialog mit Dir!
-      Isabelle Buckow, Astrid Csuraji, Jakob Vicari und Bertram Weiß
+      Herzlich Willkommen bei #50survivors. Danke, dass Sie an unserer Dialog-Recherche teilnehmen. In den kommenden Wochen nutzen wir Telegram für den Austausch. Ein Bot arbeitet wie ein Postbote für uns und stellt Fragen und Antworten zu. Ihre Nachrichten lesen und beantworten wir aber selbstverständlich persönlich. Wir freuen uns sehr auf den Dialog mit Ihnen!
+      Katharina Jakob, Jens Eber, Oliver Eberhardt, Isabelle Buckow, Astrid Csuraji und Jakob Vicari
 
   onboarding:
     heading: "Hallo und willkommen beim #Schweinesystem!"
     intro: |
       <p>Wir freuen uns, dass Sie an unserer Dialog-Recherche zur Schweinehaltung in Deutschland teilnehmen. Denn dort zeigen sich überall schwerwiegende Probleme: Schlachthofskandale, menschenunwürdige Arbeitsbedingungen, Tierqualen, dazu ein rapider Preisverfall, der Schweinebauern ruiniert. So kann es nicht weitergehen. Das weiß jeder, der mit diesem Markt zu tun hat.</p>
-      <p>Lösungsvorschläge gibt es bisher keine. Deswegen starten wir diese Dialogrecherche mit Ihrer Hilfe. Statt mit ein bis drei Betroffenen oder Experten ein Interview zu führen und dann einen Beitrag zu veröffentlichen, wollen wir mit vielen verschiedenen Menschen das Gespräch suchen. Und das über einen Zeitraum von vier Wochen. Damit wir ein breiteres Bild bekommen und Dinge besser verstehen.</p>
+      <p>Lösungsvorschläge gibt es bisher keine. Deswegen starten wir diese Dialog-Recherche mit Ihrer Hilfe. Statt mit ein bis drei Betroffenen oder Experten ein Interview zu führen und dann einen Beitrag zu veröffentlichen, wollen wir mit vielen verschiedenen Menschen das Gespräch suchen. Und das über einen Zeitraum von vier Wochen. Damit wir ein breiteres Bild bekommen und Dinge besser verstehen.</p>
       <p>Es ist ein Experiment. Danke, dass Sie sich darauf einlassen.</p>
     who:
       heading: Wer?
       text: |
-        Hinter dem #Schweinesystem stecken Menschen, keine Maschinen: Die Journalisten Katharina Jakob und Jens Eber, der Filmemacher Oliver Eberhardt sowie das Dialogrecherche-Team Isabelle Buckow, Astrid Csuraji und Dr. Jakob Vicari von tactile.news. <a class="Link" href=" https://tactile.news/ueber-uns/">Auf unserer Webseite</a> stellen wir unsere Idee vom Dialog-Journalismus ausführlicher vor.
+        Hinter dem #Schweinesystem stecken Menschen, keine Maschinen: Die Journalisten Katharina Jakob und Jens Eber, der Filmemacher Oliver Eberhardt sowie das Dialog-Recherche-Team Isabelle Buckow, Astrid Csuraji und Dr. Jakob Vicari von tactile.news. <a class="Link" href=" https://tactile.news/ueber-uns/">Auf unserer Webseite</a> stellen wir unsere Idee vom Dialog-Journalismus ausführlicher vor.
     how:
       heading: Wie?
       text: |
-        Wir stellen Ihnen in den nächsten vier, fünf Wochen immer mal wieder eine Frage. Am liebsten per Telegram Messenger. Wenn Sie den nicht nutzen und auch nicht installieren wollen (er ist sehr ähnlich wie Whatsapp), kommunizieren Sie mit uns per E-Mail. Es bleibt Ihnen überlassen, ob Sie jede Frage beantworten oder auch welche auslassen.
+        Wir stellen Ihnen in den nächsten vier, fünf Wochen immer mal wieder eine Frage. Am liebsten per Telegram Messenger. Wenn Sie den nicht nutzen und auch nicht installieren wollen (er ist sehr ähnlich wie WhatsApp), kommunizieren Sie mit uns per E-Mail. Es bleibt Ihnen überlassen, ob Sie jede Frage beantworten oder auch welche auslassen.
     where:
       heading: Wo?
       text: |

--- a/spec/requests/telegram/webhook_spec.rb
+++ b/spec/requests/telegram/webhook_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Telegram::WebhookController, telegram_bot: :rails do
     let(:welcome_message) do
       message = [
         'Herzlich Willkommen bei #50survivors.',
-        'Danke, dass Du an unserer Dialogrecherche teilnimmst.',
+        'Danke, dass Sie an unserer Dialog-Recherche teilnehmen.',
         'In den kommenden Wochen nutzen wir Telegram für den Austausch.',
         'Ein Bot arbeitet wie ein Postbote für uns und stellt Fragen und Antworten zu.',
-        'Deine Nachrichten lesen und beantworten wir aber selbstverständlich persönlich.',
-        'Wir freuen uns sehr auf den Dialog mit Dir!'
+        'Ihre Nachrichten lesen und beantworten wir aber selbstverständlich persönlich.',
+        'Wir freuen uns sehr auf den Dialog mit Ihnen!'
       ].join(' ')
 
-      message + "\nIsabelle Buckow, Astrid Csuraji, Jakob Vicari und Bertram Weiß"
+      message + "\nKatharina Jakob, Jens Eber, Oliver Eberhardt, Isabelle Buckow, Astrid Csuraji und Jakob Vicari"
     end
 
     subject { -> { dispatch_command :start, { from: { username: 'Joe' } } } }


### PR DESCRIPTION
- [x] Fix inconsistent usage of "Sie" and "Du"
- [x] Fix inconsistent spelling of "Dialog-Recherche"
- [x] Fix spelling of "WhatsApp"
- [x] Fix date in onboarding success view
- [x] Fix team members in Telegram welcome message (waiting for feedback)