### PR TITLE
Always show request stats

### DIFF
--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -22,16 +22,16 @@
 <%= c 'box', style: :large do %>
   <%= c 'wrapper' do %>
 
-    <% if @message_groups.blank? %>
+    <%= c 'stack', space: :xlarge do %>
+      <%= c 'request_metrics', request: @request, style: :cards %>
 
-      <%= c 'empty_state' do %>
-        <%= I18n.t 'request.no_replies' %>
-      <% end %>
+      <% if @message_groups.blank? %>
 
-    <% else %>
+        <%= c 'empty_state' do %>
+          <%= I18n.t 'request.no_replies' %>
+        <% end %>
 
-      <%= c 'stack', space: :xlarge do %>
-        <%= c 'request_metrics', request: @request, style: :cards %>
+      <% else %>
 
         <%= c 'stack' do %>
           <%= c 'heading', tag: :h2 do %>
@@ -42,6 +42,7 @@
             <%= c 'chat_messages_group', user: user, messages: messages %>
           <% end %>
         <% end %>
+
       <% end %>
 
     <% end %>


### PR DESCRIPTION
This allows editors to see the total number of recipients of a requests directly after they’ve sent it. (Close #406)

**Before:**
<img width="1092" alt="Screen Shot 2020-10-17 at 12 55 40" src="https://user-images.githubusercontent.com/1512805/96335327-3a969880-1078-11eb-94e8-17a550c4a655.png">


**After:**
<img width="1092" alt="Screen Shot 2020-10-17 at 12 55 03" src="https://user-images.githubusercontent.com/1512805/96335329-3e2a1f80-1078-11eb-964d-0c1598af33b1.png">
