### PR TITLE
Add credentials to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore credentials
+/config/**/*.key
+
 # Ignore uploaded files in development.
 /storage/*
 !/storage/.keep


### PR DESCRIPTION
Even though we don’t use encrypted credentials anymore, developer might still have the *.key files in their working directory. To be extra cautious, let’s add them back to `.gitignore`.