### PR TITLE
build: remove webpack service

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,13 +19,8 @@ services:
 
   app:
     <<: *x-defaults
-    depends_on: [ webpack, db, mailserver ]
+    depends_on: [ db, mailserver ]
     ports: ['3000:3000']
-
-  webpack:
-    <<: *x-defaults
-    command: ./bin/webpack-dev-server
-    ports: [ '3035:3035' ]
 
   db:
     environment:


### PR DESCRIPTION
@tillprochaska in development environment, the assets are rebuild when I
run `bin/rails webpacker:clobber` no need for an extra service,
apparently. What was the service for originally?