### PR TITLE
Use classic `FileUpdateChecker` instead of watcher-based implementation

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # CUSTOM
   config.mailer = {


### PR DESCRIPTION
There seems to be a bug in Docker for Mac (and probably also for Windows) which prevents file system events to propagate into containers. As a result, Rails doesn’t automatically reload changed source files in the development environment.

It’s a [known issue](https://github.com/docker/for-mac/issues/4962) and a fix should land in the near future. For the meantime, it’d be nice if we could use the classic `FileSystemChecker` which doesn’t rely on file system events. I’ve subscribed to updates on the issues mentioned and will revert that change once the bug has been fixed.