### PR TITLE
Add `lang` attribute to root element

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title><%= t 'application_name' %></title>
     <%= csrf_meta_tags %>

--- a/app/views/layouts/onboarding.html.erb
+++ b/app/views/layouts/onboarding.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="smooth-scrolling">
+<html lang="<%= I18n.locale %>" class="smooth-scrolling">
 <head>
   <title><%= t 'application_name' %></title>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
@mattwr18: One positive outcome (hopefully of many others to come 😉) of our discussion over at #439 is I noticed we’re currently missing the `lang` attribute on the root element. This PR adds it so screen readers know which voice to use when reading out the contents. :)