### PR TITLE
fix: typo on settings model

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -5,7 +5,7 @@ class Setting < RailsSettings::Base
   cache_prefix { 'v1' }
 
   field :project_name, default: ENV['HUNDRED_EYES_PROJECT_NAME'] || '100eyes'
-  field :application_host, readonly: true, default: ENV['APPLICATION_HOST'] || 'http://localhost:3000'
+  field :application_host, readonly: true, default: ENV['APPLICATION_HOSTNAME'] || 'localhost:3000'
 
   field :onboarding_logo, default: '/onboarding/logo.png'
   field :onboarding_hero, default: '/onboarding/hero.jpg'


### PR DESCRIPTION
It should all be one environment variable. I used `APPLICATION_HOSTNAME`
for now. I tested the code with the following:

```
$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
$ docker-compose exec app bin/rails telegram:bot:set_webhook
```

And the following vars in `.env`:
```
TELEGRAM_BOT_USERNAME ...
TELEGRAM_BOT_API_KEY ...
APPLICATION_HOSTNAME ...
RAILS_ENV=production
```

close #483 