### PR TITLE
refactor: do not remove exited containers

### DIFF
--- a/ansible/roles/installation/tasks/main.yml
+++ b/ansible/roles/installation/tasks/main.yml
@@ -56,7 +56,6 @@
 
 - name: Prune outdated images
   community.general.docker_prune:
-    containers: yes
     images: yes
 
 - name: Create and migrate database


### PR DESCRIPTION
This makes it easier to debug problems in production. Keeping the
container there allows us to do:
```bash
$ docker logs <CONTAINER_ID>
```