### PR TITLE
Add environment variable to set database name

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,7 @@ x-defaults: &x-defaults
     MAILSERVER_HOST: mailserver
     MAILSERVER_PORT: 25
     POSTGRES_HOST: db
+    POSTGRES_DB: "${POSTGRES_DB:-app_development}"
     WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
   stdin_open: true
   tty: true


### PR DESCRIPTION
This PR exposes the `POSTGRES_DB` environment variable Rails uses to determine which database to you use for development. This comes in handy when trying to verify a backup, maintaining two different databases when working on two features in parallel, …