### PR TITLE
Update Readme to include required Ansible collection

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -4,12 +4,10 @@ Our setup uses a number of community-maintained Ansibles roles. Install them usi
 
 ```
 ansible-galaxy collection install community.general
+ansible-galaxy collection install devsec.hardening
 ansible-galaxy install geerlingguy.docker
 ansible-galaxy install geerlingguy.pip
-ansible-galaxy install dev-sec.os-hardening
-ansible-galaxy install dev-sec.ssh-hardening
 ```
-
 
 Generate configuration files:
 ```bash


### PR DESCRIPTION
The `site.yml` playbook uses the `os-hardening` and `ssh-hardening` roles from the `devsec.hardening` collection. While you can still install them separately as explained in the Readme, the fully qualified name to include those roles is different.