### PR TITLE
refactor: become sudo when creating a backup

### DIFF
--- a/ansible/backup.yml
+++ b/ansible/backup.yml
@@ -1,9 +1,11 @@
 ---
 - hosts: webservers
+  become: yes
   tasks:
     - set_fact:
         backup_directory: "backups/{{ ansible_date_time.iso8601_basic_short }}"
       run_once: true
 - hosts: webservers
+  become: yes
   roles:
     - role: backup


### PR DESCRIPTION
For reasons you have to be root in order to run a `python` executable on
Digital Ocean. Maybe we should dig into this in order to run the backup
as a non-root user on Digital Ocean, too.