### PR TITLE
fix: safelist links to uploads

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
-# Allow 5 requests per 2 seconds per ip address at max
+# TODO: upload our files to an external object storage to reduce load from our application server
+Rack::Attack.safelist('allow uploads') do |request|
+  request.path.start_with?('/rails/active_storage/')
+end
+
 Rack::Attack.throttle('requests per ip', limit: 5, period: 2, &:ip)


### PR DESCRIPTION
Close #578 

How I tested this:

1. Restore remote backup:
```
$ ansible-playbook ansible/backup.yml -i ansible/inventories/production --ask-vault-pass
$ ansible-playbook ansible/restore_locally.yml
```

2. Log out `request.query` when the safelist is matched.
3. Visit a route with a picture.
