### PR TITLE
Display line breaks in HTML version of outbound emails

### DIFF
--- a/app/views/mailer/mailer.html.erb
+++ b/app/views/mailer/mailer.html.erb
@@ -5,7 +5,7 @@
   </head>
 
   <body>
-    <%= @text %>
+    <%= simple_format(@text) %>
     <br>
     <br>
     --

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -31,9 +31,22 @@ RSpec.describe Mailer, type: :mailer do
       it { should eq(['TestingProject <100eyes-test-account@example.org>']) }
     end
 
-    describe 'body' do
+    describe 'plaintext body' do
       subject { mail.text_part.body.decoded }
+
       it { should include I18n.t('mailer.unsubscribe.text') }
+    end
+
+    describe 'html body' do
+      let(:text) { "How do you do?\n\nHere’s another line!" }
+      subject { mail.html_part.body }
+
+      it { should include I18n.t('mailer.unsubscribe.html') }
+
+      it 'formats plain text' do
+        subject.should have_css('p', exact_text: 'How do you do?')
+        subject.should have_css('p', exact_text: 'Here’s another line!')
+      end
     end
 
     describe 'message_stream' do


### PR DESCRIPTION
Close #555.

When we switched to Postmark as our email provider, we also started sending out HTML emails. We do this mainly in order to hide the long unsubscribe URL in the email footer behind a short text label. Before, we’ve been sending plain text messages only.

When I added support for HTML variants, I forgot to think about converting line breaks to `<br>` tags. So when sending out a request like this…

<img width="452" alt="Screen Shot 2020-12-07 at 14 27 41" src="https://user-images.githubusercontent.com/1512805/101356473-670cab00-3898-11eb-9a5b-8bb5e83e1c8c.png">
 
… it would be displayed without line breaks for most contributors:

<img width="223" alt="Screen Shot 2020-12-07 at 14 27 31" src="https://user-images.githubusercontent.com/1512805/101356501-74299a00-3898-11eb-8203-b40008ff539d.png">

This PR makes use of the Rails helper `simple_format` which converts paragraphs separated by multiple line breaks to `<p>` tags, and converts single line breaks to a `<br>` tag.