### PR TITLE
Fix overflow in chat messages due to long unsubscribe links

### DIFF
--- a/app/components/plaintext_message/plaintext_message.css
+++ b/app/components/plaintext_message/plaintext_message.css
@@ -1,3 +1,4 @@
 .PlaintextMessage {
   white-space: pre-line;
+  word-break: break-word;
 }


### PR DESCRIPTION
Close #556.

The issues @drjakob and @FrauCsu have mentioned in our call earlier today is related to those long unsubscribe links in the respective messages, as they don’t contain any "natural break points" (i.e. spaces, punctuation etc.), so the browser isn’t able to insert line breaks automatically.

**Before:**
<img width="700" alt="Screen Shot 2020-12-07 at 09 34 51" src="https://user-images.githubusercontent.com/1512805/101327836-8d6a2080-386f-11eb-8a21-f7a81af958e1.png">

**After:**
<img width="500" alt="Screen Shot 2020-12-07 at 09 35 03" src="https://user-images.githubusercontent.com/1512805/101327855-90651100-386f-11eb-8b03-cd9364b3b225.png">
