### PR TITLE
Update logo link in nav bar

### DIFF
--- a/app/components/nav_bar/nav_bar.html.erb
+++ b/app/components/nav_bar/nav_bar.html.erb
@@ -2,7 +2,7 @@
   <nav>
     <ul>
       <li class="NavBar-item">
-        <%= link_to root_path, class: 'NavBar-logo' do %>
+        <%= link_to dashboard_path, class: 'NavBar-logo' do %>
           <%= t 'application_name' %>
         <% end %>
       </li>


### PR DESCRIPTION
Close #551.

As we’re routing requests to `/` to a landing page outside of the scope of this application, clicking the logo link in the nav bar would in those cases route you to the landing page and not to the dashboard.