### PR TITLE
Prevent unrelated validation errors due to relative URLs in settings

### DIFF
--- a/app/components/onboarding_header/onboarding_header.css
+++ b/app/components/onboarding_header/onboarding_header.css
@@ -8,6 +8,13 @@
   margin: var(--spacing-unit-xs) auto;
 }
 
+.OnboardingHeader__logoText {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  font-size: .8rem;
+}
+
 .OnboardingHeader-byline {
   font-size: var(--font-size-xs);
   color: var(--color-text-light);

--- a/app/components/onboarding_header/onboarding_header.html.erb
+++ b/app/components/onboarding_header/onboarding_header.html.erb
@@ -1,5 +1,12 @@
 <header class="<%= class_attr %>">
-  <img src="<%= logo %>" alt="<%= Setting.project_name %>" />
+  <% if logo.present? %>
+    <img src="<%= logo %>" alt="<%= Setting.project_name %>" />
+  <% else %>
+    <div class="OnboardingHeader__logoText">
+      <%= Setting.project_name %>
+    </div>
+  <% end %>
+
   <span class="OnboardingHeader-byline">
     <%= I18n.t('components.onboarding_header.byline').html_safe %>
   </span>

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -7,9 +7,9 @@ class Setting < RailsSettings::Base
   field :project_name, default: ENV['HUNDRED_EYES_PROJECT_NAME'] || '100eyes'
   field :application_host, readonly: true, default: ENV['APPLICATION_HOSTNAME'] || 'localhost:3000'
 
-  field :onboarding_logo, default: '/onboarding/logo.png'
-  field :onboarding_hero, default: '/onboarding/hero.jpg'
-  field :onboarding_title, default: 'Hallo und herzlich willkommen beim 100eyes!'
+  field :onboarding_logo
+  field :onboarding_hero
+  field :onboarding_title, default: 'Hallo und herzlich willkommen!'
   field :onboarding_page, default: File.read(File.join('config', 'locales', 'onboarding', 'page.md'))
   field :onboarding_success_heading, default: File.read(File.join('config', 'locales', 'onboarding', 'success_heading.txt'))
   field :onboarding_success_text, default: File.read(File.join('config', 'locales', 'onboarding', 'success_text.txt'))

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -6,8 +6,10 @@
 
 <main>
 
-  <%= c 'wrapper' do %>
-    <%= c 'onboarding_hero', image: Setting.onboarding_hero %>
+  <% if Setting.onboarding_hero.present? %>
+    <%= c 'wrapper' do %>
+      <%= c 'onboarding_hero', image: Setting.onboarding_hero %>
+    <% end %>
   <% end %>
 
   <%= c 'wrapper', style: :narrow do %>


### PR DESCRIPTION
🚨 This PR is based on #617 -- please do not merge this until #617 has been merged.

***

Hi @mattwr18, this is another idea to solve #585. The main problem about the URL inputs is not that editors would actually want to enter relative URLs, but that we’re using relative URLs as default values, and these cause browser validation errors when updating (other) settings. However, the default values don’t make sense anyways -- they reference a logo and header image that was specifically created for #Schweinesystem and thus they can’t be used for any other project.

For more recent projects, we’ve actually always used image assets uploaded to a separate web server and referenced them using absolute URLs. (And even for projects were we’re still referencing assets on the same host, it’d be easy use absolute URLs instead.)

So as we don’t really have sensible defaults for the header and logo, this PR instead makes those two settings optional. The header image is purely decorative anyways. If you don’t reference a project logo, the project title will be displayed instead. And without a header image URL, we simply do not display a header image. That’s it.

<img src="https://user-images.githubusercontent.com/1512805/104858785-f9857d00-5921-11eb-996c-d7502141f900.png" alt="" width="350" />

Close #585 