### PR TITLE
refactor: use node lts version for development

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 ruby 2.7.2
-nodejs 14.15.4
+nodejs lts


### PR DESCRIPTION
:tada: Symlinks are implemented in `asdf-nodejs`.

See: https://github.com/asdf-vm/asdf-nodejs/pull/176