### PR TITLE
Fix laggy card hover transition

### DIFF
--- a/app/components/card/card.css
+++ b/app/components/card/card.css
@@ -8,6 +8,5 @@
 }
 
 a .Card:hover {
-  transform: translateY(-2px);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 5px 20px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
In Chrome on macOS, the card hover transition was super laggy, which is annoying. The usual trick to improve transition performance didn’t work, so instead of spending too much time tracking this down, I decided to simply not change the card’s position on hover.

**Before:** Card’s moved up by 2px on hover
https://user-images.githubusercontent.com/1512805/105782317-96749580-5f74-11eb-9547-1d48aab65c4f.mov

**After:** Card doesn’t move, but transition isn’t laggy :)
https://user-images.githubusercontent.com/1512805/105782365-b015dd00-5f74-11eb-84de-91502e1949b2.mov

