### PR TITLE
fix: increase inotify watchers on production

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -7,6 +7,7 @@ ansible-galaxy collection install community.general
 ansible-galaxy collection install devsec.hardening
 ansible-galaxy install geerlingguy.docker
 ansible-galaxy install geerlingguy.pip
+ansible-galaxy install gantsign.inotify
 ```
 
 Generate configuration files:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -14,6 +14,8 @@
     - role: initial_setup
     - role: devsec.hardening.ssh_hardening
     - role: devsec.hardening.os_hardening
+    - role: gantsign.inotify
+      inotify_max_user_watches: 524288
     - role: geerlingguy.pip
       vars:
         pip_install_packages:


### PR DESCRIPTION
I tested this commit by running the deployment first, verifying that inofify watchers are too low:
```
$ cat /proc/sys/fs/inotify/max_user_watches
8192
```

After applying the changes I could see a new file `20-ansible-inotify.conf` in `/etc/sysctl.d`.

And increased number of inotify watchers:
```
$ cat /proc/sys/fs/inotify/max_user_watches 524288
```

And I could start rails console:
```
$ docker exec -it 8ed31749b0f1 bin/rails c
Running via Spring preloader in process 44
WARNING: Spring is running in production. To fix this make sure the spring gem is only present in `development` and `test` groups in your Gemfile and make sure you always use `bundle install --without development test` in production
Loading production environment (Rails 6.0.3.4)
```

I checked the ansible role source code at https://github.com/gantsign/ansible-role-inotify/blob/master/tasks/main.yml:
https://github.com/gantsign/ansible-role-inotify
Looks reasonable. I starred the repo.

Along the way, I learned about another testing tool for ansible roles called "Molecure":
https://github.com/ansible-community/molecule

fix #661