### PR TITLE
Fix heading level and missing closing tag

### DIFF
--- a/app/components/footer/footer.html.erb
+++ b/app/components/footer/footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="Footer">
 
   <div class="Footer-column">
-    <%= c 'heading', tag: :h3, style: :upper do %>
+    <%= c 'heading', tag: :h2, style: :upper do %>
       <%= I18n.t 'components.footer.authors.heading' %>
     <% end %>
 
@@ -9,7 +9,7 @@
   </div>
 
   <div class="Footer-column">
-    <%= c 'heading', tag: :h3, style: :upper do %>
+    <%= c 'heading', tag: :h2, style: :upper do %>
       <%= I18n.t 'components.footer.funding.heading' %>
     <% end %>
 
@@ -27,7 +27,7 @@
   </div>
 
   <div class="Footer-column">
-    <%= c 'heading', tag: :h3, style: :upper do %>
+    <%= c 'heading', tag: :h2, style: :upper do %>
       <%= I18n.t 'components.footer.license.heading' %>
     <% end %>
 
@@ -41,5 +41,6 @@
       <%= c 'icon', icon: 'logo-github', style: :inline %>
       GitHub
     </a>
+  </div>
 
 </footer>


### PR DESCRIPTION
I think @mattwr18 mentioned that we’re using the wrong heading level for the headings in the footer -- this is a super small PR that fixes that. Also, I spotted a missing closing tag in the footer.