### PR TITLE
Fix broken asdf install for local dev

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.2
-nodejs lts
+ruby 2.7.1
+nodejs lts-erbium


### PR DESCRIPTION
Fixes #679 

I have opted for `lts-erbium`(nodejs v12 - Maintenance LTS) over `lts-fermium` (nodejs v14 Active LTS) because we are using nodejs v12 in production and I think we want to keep the local setup as similar as possible to the production setup.

I have used ruby 2.7.1 because there is no 2.7.2 in the ruby plugin for asdf so, even though we use 2.7.2 in production, it's as close as we can get with asdf. 