### PR TITLE
feat: Display Threema ID

### DIFF
--- a/app/components/contributor_form/contributor_form.html.erb
+++ b/app/components/contributor_form/contributor_form.html.erb
@@ -25,7 +25,7 @@
     <% end %>
 
     <%= c 'field', object: contributor, id: :threema_id, styles: [:horizontal] do |field| %>
-      <%= c 'input', field.input_defaults.merge(disabled: true) %>
+      <%= c 'input', field.input_defaults %>
     <% end %>
 
     <%= c 'field', object: contributor, id: :zip_code, styles: [:horizontal] do |field| %>

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -57,7 +57,8 @@ class ContributorsController < ApplicationController
   end
 
   def contributor_params
-    params.require(:contributor).permit(:note, :first_name, :last_name, :avatar, :email, :phone, :zip_code, :city, :tag_list, :active)
+    params.require(:contributor).permit(:note, :first_name, :last_name, :avatar, :email, :threema_id, :phone, :zip_code, :city, :tag_list,
+                                        :active)
   end
 
   def message_params

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -208,7 +208,6 @@ de:
       threema_id:
         label: Threema ID
         placeholder: Keine Threema-ID hinterlegt
-        title: Du kannst die Threema-ID nicht selbst ändern. Bei Bedarf, z.B. bei fehlerhaften Threema-IDs, kann ein Administrator weiterhelfen.
       zip_code:
         label: Postleitzahl
       city:


### PR DESCRIPTION
I think this is a very useful feature for users to contact the
contributor directly via Threema, if necessary. Also, it might help us
to spot invalid threema ids.


![swappy-20210218_153338](https://user-images.githubusercontent.com/2110676/108372071-b6f3e080-71fe-11eb-9d5e-4674b1c60030.png)
