### PR TITLE
feat: Make threema id mutable

### DIFF
--- a/app/components/contributor_form/contributor_form.html.erb
+++ b/app/components/contributor_form/contributor_form.html.erb
@@ -25,7 +25,7 @@
     <% end %>
 
     <%= c 'field', object: contributor, id: :threema_id, styles: [:horizontal] do |field| %>
-      <%= c 'input', field.input_defaults.merge(disabled: true) %>
+      <%= c 'input', field.input_defaults %>
     <% end %>
 
     <%= c 'field', object: contributor, id: :zip_code, styles: [:horizontal] do |field| %>

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -57,7 +57,8 @@ class ContributorsController < ApplicationController
   end
 
   def contributor_params
-    params.require(:contributor).permit(:note, :first_name, :last_name, :avatar, :email, :phone, :zip_code, :city, :tag_list, :active)
+    params.require(:contributor).permit(:note, :first_name, :last_name, :avatar, :email, :threema_id, :phone, :zip_code, :city, :tag_list,
+                                        :active)
   end
 
   def message_params

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -208,7 +208,6 @@ de:
       threema_id:
         label: Threema ID
         placeholder: Keine Threema-ID hinterlegt
-        title: Du kannst die Threema-ID nicht selbst ändern. Bei Bedarf, z.B. bei fehlerhaften Threema-IDs, kann ein Administrator weiterhelfen.
       zip_code:
         label: Postleitzahl
       city:


### PR DESCRIPTION
This is a to-be-discussed commit which would allow users to edit wrong
threema ids without asking administrators. I don't know if we want this.

![swappy-20210218_153721](https://user-images.githubusercontent.com/2110676/108372554-3c779080-71ff-11eb-9bf2-3a9f774f22e2.png)
