### PR TITLE
Fix exception when trying to move an outbound message

### DIFF
--- a/app/components/chat_message/chat_message.html.erb
+++ b/app/components/chat_message/chat_message.html.erb
@@ -66,9 +66,11 @@
           </span>
         <% end %>
 
-        <%= c 'button', style: :inline, link: move_link do %>
-          <%= c 'icon', icon: 'direction-right', style: :inline %>
-          <%= I18n.t('components.chat_message.move') %>
+        <% if message.reply? %>
+          <%= c 'button', style: :inline, link: move_link do %>
+            <%= c 'icon', icon: 'direction-right', style: :inline %>
+            <%= I18n.t('components.chat_message.move') %>
+          <% end %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/messages/requests/show.html.erb
+++ b/app/views/messages/requests/show.html.erb
@@ -10,7 +10,7 @@
         <p>
           <%= t(
             'message.move.text',
-            name: @message.sender.name,
+            name: @message.contributor.name,
             title: @message.request.title
           ).html_safe %>
         </p>

--- a/spec/components/chat_message_spec.rb
+++ b/spec/components/chat_message_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe ChatMessage::ChatMessage, type: :component do
       it { should have_text('<h1>Hello!</h1>') }
     end
   end
+
+  describe 'move action' do
+    context 'given an inbound message' do
+      let(:message) { create(:message) }
+
+      it 'is present' do
+        expect(subject).to have_css('a', text: I18n.t('components.chat_message.move'))
+      end
+    end
+
+    context 'given an outbound message' do
+      let(:message) { create(:message, sender: nil) }
+
+      it 'is hidden' do
+        expect(subject).to_not have_css('a', text: I18n.t('components.chat_message.move'))
+      end
+    end
+  end
 end

--- a/spec/requests/messages_request_spec.rb
+++ b/spec/requests/messages_request_spec.rb
@@ -42,6 +42,31 @@ RSpec.describe 'Messages', type: :request do
     end
   end
 
+  describe 'GET /request' do
+    let(:user) { create(:user) }
+    let(:contributor) { create(:contributor, first_name: 'Zora', last_name: 'Zimmermann') }
+
+    before(:each) { get(message_request_url(message, as: user)) }
+
+    context 'given an inbound message' do
+      let(:message) { create(:message, sender: contributor, recipient: nil) }
+
+      it 'renders successfully' do
+        expect(response).to be_successful
+        expect(response.body).to include('Zora Zimmermann')
+      end
+    end
+
+    context 'given an outbound message' do
+      let(:message) { create(:message, sender: nil, recipient: contributor) }
+
+      it 'renders successfully' do
+        expect(response).to be_successful
+        expect(response.body).to include('Zora Zimmermann')
+      end
+    end
+  end
+
   describe 'POST /request' do
     let(:user) { create(:user) }
     let(:request) { create(:request) }


### PR DESCRIPTION
Close #726.

* I removed the move action from outbound chat messages. This feature has been designed and implemented to handle inbound messages that have been automatically associated with the wrong request, thus I don’t think it makes sense to expose it for outbound messages.

* I updated the view for `messages#request` so that it doesn’t throw an exception in case of outbound messages, so in case someone really wants to move an outbound message, they can do that by manually navigating to the respective route.