### PR TITLE
Raise specified postgresql version in Dockerfile to =~12.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk --update add \
     git \
     nodejs \
     yarn \
-    postgresql-dev=~12.5 \
-    postgresql-client=~12.5 \
+    postgresql-dev=~12.6 \
+    postgresql-client=~12.6 \
     tzdata \
     libxslt-dev \
     libxml2-dev \


### PR DESCRIPTION
![](https://media1.tenor.com/images/16d21ad4f1824ab0959a5a8ce764d8ca/tenor.gif?itemid=16630236)
Different error message, same problem and fix as #549, because we got a new postgresql version on Alpine Linux on Wednesday: https://pkgs.alpinelinux.org/packages?name=postgresql&branch=v3.11. 