### PR TITLE
translate: fix translations for OTP copy/paste

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -96,8 +96,8 @@ de:
       step_1: "1. Fügen Sie 100eyes zu einer App wie Authy oder FreeOTP hinzu, indem Sie entweder den folgenden QR-Code scannen oder den geheimen Schlüssel manuell kopieren."
       step_2: "2. Geben Sie den 6-stelligen Bestätigungscode ein."
       copy_secret_key:
-        label: Geheimen Schlüssel kopiert
-        success: Schlüssel kopieren
+        label: Schlüssel kopieren
+        success: Geheimen Schlüssel kopiert
     move_message_form:
       submit: Verschieben
       cancel: Abbrechen


### PR DESCRIPTION
The labels are in the exactly wrong order.