### PR TITLE
build(update): ruby v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.0.0
           bundler-cache: true
 
       - name: Cache NPM dependencies

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.1
+ruby 3.0.0
 nodejs lts-erbium

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine3.11
+FROM ruby:3.0.2-alpine3.12
 
 # Install dependencies
 RUN apk --update add \

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '~> 2.7.1'
+ruby '~> 3.0.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.4'
@@ -93,8 +93,6 @@ gem 'postmark-rails'
 gem 'active_model_otp'
 gem 'clearance'
 gem 'rqrcode'
-
-gem 'threema', git: 'https://github.com/tactilenews/threema.git', branch: 'master'
-
 gem 'sentry-rails'
 gem 'sentry-ruby'
+gem 'threema', git: 'https://github.com/tactilenews/threema.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
+    mime-types-data (3.2021.0901)
     mini_magick (4.11.0)
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
@@ -431,7 +431,7 @@ DEPENDENCIES
   webpacker (~> 5)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 3.0.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.2.9

--- a/app/components/attribute_bag.rb
+++ b/app/components/attribute_bag.rb
@@ -5,7 +5,7 @@ class AttributeBag
 
   attr_reader :attrs
 
-  def initialize(**attrs)
+  def initialize(attrs = {})
     @attrs = attrs
   end
 
@@ -19,7 +19,7 @@ class AttributeBag
     attrs
   end
 
-  def merge(**additional_attrs)
+  def merge(additional_attrs = {})
     new_attrs = attrs.dup
 
     if attrs.key?(:class) && additional_attrs.key?(:class)
@@ -30,7 +30,7 @@ class AttributeBag
     self.class.new(**new_attrs.deep_merge(additional_attrs))
   end
 
-  def defaults(**default_attrs)
+  def defaults(default_attrs = {})
     self.class.new(**default_attrs).merge(**attrs)
   end
 

--- a/app/components/onboarding_telegram_fallback/onboarding_telegram_fallback.rb
+++ b/app/components/onboarding_telegram_fallback/onboarding_telegram_fallback.rb
@@ -14,7 +14,7 @@ module OnboardingTelegramFallback
 
     def fallback_steps
       data = { telegram_handle: Setting.telegram_bot_username, token: telegram_onboarding_token }
-      I18n.t('components.onboarding_telegram_fallback.steps', data)
+      I18n.t('components.onboarding_telegram_fallback.steps', **data)
     end
   end
 end

--- a/spec/mailboxes/replies_mailbox_spec.rb
+++ b/spec/mailboxes/replies_mailbox_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe RepliesMailbox, type: :mailbox do
-  subject { -> { receive_inbound_email_from_mail params } }
+  subject { -> { receive_inbound_email_from_mail(**params) } }
 
   let(:from_address) { 'zora@example.org' }
   let(:params) { { from: from_address, body: 'Meiner Katze geht es gut!' } }


### PR DESCRIPTION
This should update only ruby to v3. I specified `alpine3.12` because
`alpine3.13` already has just postgres v13 tooling in their package
registry.
