### PR TITLE
Add i18n to via channels text in contributor row

### DIFF
--- a/app/components/contributor_row/contributor_row.html.erb
+++ b/app/components/contributor_row/contributor_row.html.erb
@@ -12,7 +12,7 @@
     </strong>
 
     <span class="ContributorRow-channels"> 
-        via <%= channels %>
+        <%= I18n.t('components.contributor_row.via_channels', channels: channels) %>
     </span>
 
     <% if contributor.tags? %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -21,6 +21,8 @@ de:
       submit: Absenden
     chat_message_audio:
       no_audio_support: Dein Browser unterstützt das Audio Element nicht
+    contributor_row:
+      via_channels: via %{channels}
     nav_bar:
       community:
         other: Community


### PR DESCRIPTION
As we just talked about i18n in the stand-up today - I forgot to add 18n for the contributor channel tags. This PR fixes that.