### PR TITLE
Fix CI syntax error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Install ruby
-        uses: actions/setup-ruby@v1
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.2


### PR DESCRIPTION
The latest change to the `ci.yml` workflow introduced a syntax error (the `uses` key in the setup step was set twice).