### PR TITLE
Restart Docker containers on reboot

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,9 +28,11 @@ services:
     volumes:
       - ./log:/app/log
       - ./storage:/app/storage
+    restart: always
 
   db:
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       POSTGRES_USER: "${POSTGRES_USER}"
       POSTGRES_DB: "${POSTGRES_DB:-app_production}"
+    restart: always

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -39,6 +39,7 @@ services:
       - "traefik.http.routers.traefik.tls.certresolver=cloudflare"
     environment:
       - "CF_DNS_API_TOKEN=$CF_DNS_API_TOKEN"
+    restart: always
 
   app:
     labels:


### PR DESCRIPTION
Previously, rebooting the docker host wouldn’t automatically restart the Docker containers, potentially causing downtime.

This patch adds an “always” restart policy to the Traefik reverse proxy, app, and database containers.

From the [documentation on restart policies](https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy):

> Always restart the container if it stops. If it is manually stopped, it is restarted only when Docker daemon restarts or the container itself is manually restarted.

and

> If you manually stop a container, its restart policy is ignored until the Docker daemon restarts or the container is manually restarted. This is another attempt to prevent a restart loop.

I verified this actually works as expected following these steps:

* I ran the `site.yml` playbook, deploying to our staging environment using the changed Compose configuration.
* I verified the restart policies have been applied using `docker inspect -f "{{ .HostConfig.RestartPolicy }}" container_name`.
* I restarted the staging VPS using `sudo reboot`.
* I verified all containers are up after the restart using `docker ps`.

Closes #763.