### PR TITLE
Add required data processing checkbox to onboarding forms

### DIFF
--- a/app/components/checkbox/checkbox.html.erb
+++ b/app/components/checkbox/checkbox.html.erb
@@ -5,6 +5,7 @@
       id="<%= id %>"
       name="<%= name %>"
       <%= value ? 'checked' : '' %>
+      <%= required ? 'required' : '' %>
       class="Checkbox-input"
       />
       <% if styles.include?(:switch) %>

--- a/app/components/checkbox/checkbox.rb
+++ b/app/components/checkbox/checkbox.rb
@@ -2,12 +2,13 @@
 
 module Checkbox
   class Checkbox < ApplicationComponent
-    def initialize(id: nil, value: nil, group: false, label: nil, **)
+    def initialize(id: nil, value: nil, group: false, label: nil, required: false, **)
       super
       @id = id
       @value = value
       @group = group
       @label = label
+      @required = required
     end
 
     private
@@ -18,6 +19,6 @@ module Checkbox
       id
     end
 
-    attr_reader :id, :value, :group, :label
+    attr_reader :id, :value, :group, :label, :required
   end
 end

--- a/app/components/field/field.css
+++ b/app/components/field/field.css
@@ -39,3 +39,8 @@
   margin: 0;
   margin-right: var(--spacing-unit);
 }
+
+.Field--horizontal.Field--leftAligned .Field-textWrapper {
+  width: 85%;
+  order: 2;
+}

--- a/app/components/onboarding_email_form/onboarding_email_form.html.erb
+++ b/app/components/onboarding_email_form/onboarding_email_form.html.erb
@@ -22,6 +22,10 @@
         <%= c 'input', field.input_defaults.merge(placeholder: '', required: true, type: :email) %>
       <% end %>
 
+      <%= c 'field', object: @contributor, id: :data_processing_consent, styles: [:horizontal, :leftAligned] do |field| %>
+        <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
+      <% end %>
+
       <%= c 'button',
         type: 'submit',
         label: I18n.t('components.onboarding_email_form.submit'),

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
@@ -15,6 +15,10 @@
     <%= c 'input', field.input_defaults.merge(value: last_name, required: true) %>
   <% end %>
 
+  <%= c 'field', object: @contributor, id: :data_processing_consent, styles: [:horizontal, :leftAligned] do |field| %>
+    <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
+  <% end %>
+
   <%= c 'button',
     type: 'submit',
     label: I18n.t('components.onboarding_telegram_form.submit'),

--- a/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
@@ -22,6 +22,10 @@
         <%= c 'input', field.input_defaults.merge(required: true, pattern: '[A-Za-z0-9]{8}') %>
       <% end %>
 
+      <%= c 'field', object: @contributor, id: :data_processing_consent, styles: [:horizontal, :leftAligned] do |field| %>
+        <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
+      <% end %>
+
       <%= c 'button',
         type: 'submit',
         label: t('components.onboarding_threema.submit'),

--- a/app/controllers/onboarding/channel_controller.rb
+++ b/app/controllers/onboarding/channel_controller.rb
@@ -60,7 +60,7 @@ module Onboarding
     end
 
     def contributor_params
-      params.require(:contributor).permit(:first_name, :last_name, attr_name)
+      params.require(:contributor).permit(:first_name, :last_name, :data_processing_consent, attr_name)
     end
 
     def default_url_options

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -119,7 +119,7 @@ class Contributor < ApplicationRecord
   end
 
   def data_processing_consent?
-    data_processing_consented_at.nil?
+    data_processing_consented_at.present?
   end
   alias data_processing_consent data_processing_consent?
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -113,4 +113,13 @@ class Contributor < ApplicationRecord
   def active=(value)
     self.deactivated_at = ActiveModel::Type::Boolean.new.cast(value) ? nil : Time.current
   end
+
+  def data_processing_consent=(value)
+    self.data_processing_consented_at = ActiveModel::Type::Boolean.new.cast(value) ? Time.current : nil
+  end
+
+  def data_processing_consent?
+    data_processing_consented_at.nil?
+  end
+  alias data_processing_consent data_processing_consent?
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -247,6 +247,9 @@ de:
         placeholder: Klicke hier, um eine Notiz zu %{value} zu hinterlegen
       active:
         label: Aktiv
+      data_processing_consent:
+        label: Einwilligung zur Datenverarbeitung
+        help: Ich habe die <a class="Link" href="https://tactile.news/100-eyesdatenschutz-verbraucherinnen/" target="_blank">Allgemeine Nutzungsbedingungen 100eyes</a> und die <a class="Link" href="https://tactile.news/100eyes-agb-verbraucherinnen/" target="_blank">Datenschutzerklärung</a> zur Kenntnis genommen und bin mit deren Geltung einverstanden. In unserer Datenschutzerklärung ist erklärt, welche Tools wir nutzen und mit welchen Firmen wir zusammenarbeiten. Diese Partner speichern und übertragen je nach Nutzung auch Daten in Länder außerhalb der Europäischen Union.
 
   request:
     request:

--- a/db/migrate/20210428092922_add_data_processing_consent_to_contributors.rb
+++ b/db/migrate/20210428092922_add_data_processing_consent_to_contributors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDataProcessingConsentToContributors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contributors, :data_processing_consented_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_141759) do
+ActiveRecord::Schema.define(version: 2021_04_28_092922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_141759) do
     t.string "phone"
     t.datetime "deactivated_at"
     t.string "threema_id"
+    t.datetime "data_processing_consented_at"
     t.index ["email"], name: "index_contributors_on_email", unique: true
     t.index ["telegram_chat_id"], name: "index_contributors_on_telegram_chat_id", unique: true
     t.index ["telegram_id"], name: "index_contributors_on_telegram_id", unique: true

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -429,4 +429,43 @@ RSpec.describe Contributor, type: :model do
       end
     end
   end
+
+  describe '.data_processing_consent' do
+    subject { contributor.data_processing_consent }
+
+    describe 'given a contributor who has given consent' do
+      let(:contributor) { create(:contributor, data_processing_consented_at: 1.day.ago) }
+      it { should be(true) }
+    end
+
+    describe 'given a contributor who has not given consent' do
+      let(:contributor) { create(:contributor, data_processing_consented_at: nil) }
+      it { should be(false) }
+    end
+  end
+
+  describe '.data_processing_consent=' do
+    describe 'given contributor who has given consent' do
+      let(:contributor) { create(:contributor, data_processing_consent: 1.day.ago) }
+      describe 'false' do
+        it { expect { contributor.data_processing_consent = false }.to change { contributor.data_processing_consented_at }.to(nil) }
+        it { expect { contributor.data_processing_consent = false }.to change { contributor.data_processing_consented_at? }.to(false) }
+        it { expect { contributor.data_processing_consent = '0' }.to change { contributor.data_processing_consent? }.to(false) }
+        it { expect { contributor.data_processing_consent = 'off' }.to change { contributor.data_processing_consent? }.to(false) }
+      end
+    end
+
+    describe 'given contributor who has not given content' do
+      let(:contributor) { create(:contributor, data_processing_consented_at: nil) }
+      describe 'true' do
+        it {
+          expect { contributor.data_processing_consent = true }
+            .to change { contributor.data_processing_consented_at.is_a?(ActiveSupport::TimeWithZone) }.to(true)
+        }
+        it { expect { contributor.data_processing_consent = true }.to change { contributor.data_processing_consent? }.to(true) }
+        it { expect { contributor.data_processing_consent = '1' }.to change { contributor.data_processing_consent? }.to(true) }
+        it { expect { contributor.data_processing_consent = 'on' }.to change { contributor.data_processing_consent? }.to(true) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a mandatory consent to data processing checkbox on each onboarding form, this way only contributors that have given their consent can be created. The given consent is documented / saved as a timestamp in a `data_processing_consented_at` attribute for each contributor.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/34538290/116465166-288a8380-a86d-11eb-9952-4df6f44e4fdf.png">

<img width="350" alt="image" src="https://user-images.githubusercontent.com/34538290/116465209-36400900-a86d-11eb-9d7a-23de9f680e4b.png">
