### PR TITLE
Remove JS bundle from onboarding pages

### DIFF
--- a/app/views/layouts/onboarding.html.erb
+++ b/app/views/layouts/onboarding.html.erb
@@ -13,6 +13,5 @@
 
 <%= yield %>
 
-<%= javascript_pack_tag 'application' %>
 </body>
 </html>


### PR DESCRIPTION
The onboarding process doesn’t rely on JavaScript, i.e. there’s no need to include our application JS bundle on onboarding pages. Saves a few kB of data transfer and, especially on low-end devices, it may additionally decrease the delay until the page becomes interactive, as the browser doesn’t need to evaluate the JS bundle.