### PR TITLE
feat: set hostname on VPS server

### DIFF
--- a/ansible/roles/initial_setup/tasks/main.yml
+++ b/ansible/roles/initial_setup/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- include: set_hostname.yml
 - include: packages.yml
 - include: ansible_user.yml
 - include: security.yml

--- a/ansible/roles/initial_setup/tasks/set_hostname.yml
+++ b/ansible/roles/initial_setup/tasks/set_hostname.yml
@@ -1,0 +1,4 @@
+---
+- name: Set a hostname
+  ansible.builtin.hostname:
+    name: "{{ inventory_hostname }}"


### PR DESCRIPTION
How I tested this: I changed it to `"{{ inventory_hostname }}2"` and after I SSHed into staging, I could see
`ansible@staging2:~$` on the command prompt. I changed it back now.

See #834 for context.