### PR TITLE
Set same site config to lax to relax cookie policy

### DIFF
--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -7,7 +7,7 @@ Clearance.configure do |config|
   config.secure_cookie = true if Rails.env.production?
   config.mailer_sender = Setting.email_from_address
   config.rotate_csrf_on_sign_in = true
-  config.same_site = :strict
+  config.same_site = :lax
   config.redirect_url = '/dashboard'
   config.routes = false
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Rails.application.config.session_store :cookie_store, key: '_app_session', same_site: :strict
+Rails.application.config.session_store :cookie_store, key: '_app_session', same_site: :lax


### PR DESCRIPTION
Fixes #652

Ongoing issue with users(editors) being able to reset passwords.