### PR TITLE
Fix onboarding bugs and add server-side data processing consent validation

### DIFF
--- a/app/components/onboarding_threema_form/onboarding_threema_form.rb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.rb
@@ -2,10 +2,14 @@
 
 module OnboardingThreemaForm
   class OnboardingThreemaForm < ApplicationComponent
-    def initialize(**)
+    def initialize(contributor:, **)
       super
 
-      @contributor = Contributor.new
+      @contributor = contributor
     end
+
+    private
+
+    attr_reader :contributor
   end
 end

--- a/app/controllers/onboarding/channel_controller.rb
+++ b/app/controllers/onboarding/channel_controller.rb
@@ -17,7 +17,7 @@ module Onboarding
     def create
       @contributor = Contributor.new(contributor_params)
 
-      if @contributor.save
+      if @contributor.save(context: :contributor_signup)
         invalidate_jwt(jwt_param)
         redirect_to_success
       else
@@ -28,7 +28,8 @@ module Onboarding
     private
 
     def redirect_to_failure
-      redirect_to onboarding_path
+      # show validation errors
+      render :show
     end
 
     def redirect_if_contributor_exists

--- a/app/controllers/onboarding/email_controller.rb
+++ b/app/controllers/onboarding/email_controller.rb
@@ -4,11 +4,6 @@ module Onboarding
   class EmailController < ChannelController
     private
 
-    def redirect_to_failure
-      # show validation errors
-      render :show
-    end
-
     def attr_name
       :email
     end

--- a/app/controllers/onboarding/telegram_controller.rb
+++ b/app/controllers/onboarding/telegram_controller.rb
@@ -39,10 +39,14 @@ module Onboarding
     def update
       @contributor = Contributor.find_by(telegram_id: cookies.encrypted[:telegram_id])
 
+      unless @contributor
+        return redirect_to 'onboarding/unauthorized', status: :unauthorized
+      end
+
       if @contributor&.update(first_name: contributor_params[:first_name], last_name: contributor_params[:last_name])
         redirect_to_success
       else
-        render 'onboarding/unauthorized', status: :unauthorized
+        render :create
       end
     end
 

--- a/app/controllers/onboarding/telegram_controller.rb
+++ b/app/controllers/onboarding/telegram_controller.rb
@@ -43,7 +43,7 @@ module Onboarding
         return redirect_to 'onboarding/unauthorized', status: :unauthorized
       end
 
-      if @contributor&.update(first_name: contributor_params[:first_name], last_name: contributor_params[:last_name])
+      if @contributor&.update(first_name: contributor_params[:first_name], last_name: contributor_params[:last_name], data_processing_consent: contributor_params[:data_processing_consent])
         redirect_to_success
       else
         render :create
@@ -57,7 +57,7 @@ module Onboarding
     end
 
     def contributor_params
-      params.require(:contributor).permit(:first_name, :last_name, :email)
+      params.require(:contributor).permit(:first_name, :last_name, :email, :data_processing_consent)
     end
 
     def jwt_param

--- a/app/controllers/onboarding/telegram_controller.rb
+++ b/app/controllers/onboarding/telegram_controller.rb
@@ -37,13 +37,15 @@ module Onboarding
     end
 
     def update
-      @contributor = Contributor.find_by(telegram_id: cookies.encrypted[:telegram_id])
+      @contributor = cookies.encrypted[:telegram_id] ? Contributor.find_by(telegram_id: cookies.encrypted[:telegram_id]) : nil
 
-      unless @contributor
-        return redirect_to 'onboarding/unauthorized', status: :unauthorized
-      end
+      return render 'onboarding/unauthorized', status: :unauthorized unless @contributor
 
-      if @contributor&.update(first_name: contributor_params[:first_name], last_name: contributor_params[:last_name], data_processing_consent: contributor_params[:data_processing_consent])
+      if @contributor&.update(
+        first_name: contributor_params[:first_name],
+        last_name: contributor_params[:last_name],
+        data_processing_consent: contributor_params[:data_processing_consent])
+
         redirect_to_success
       else
         render :create

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -16,6 +16,8 @@ class Contributor < ApplicationRecord
   default_scope { order(:first_name, :last_name) }
   scope :active, -> { where(deactivated_at: nil) }
 
+  validates :data_processing_consent, acceptance: true, on: [:contributor_signup, :update]
+
   validates :email, uniqueness: { case_sensitive: false }, allow_nil: true, 'valid_email_2/email': true
   validates :threema_id, uniqueness: { case_sensitive: false }, allow_blank: true, format: { with: /\A[A-Za-z0-9]+\z/ }, length: { is: 8 }
 

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -16,7 +16,7 @@ class Contributor < ApplicationRecord
   default_scope { order(:first_name, :last_name) }
   scope :active, -> { where(deactivated_at: nil) }
 
-  validates :data_processing_consent, acceptance: true, on: [:contributor_signup, :update]
+  validates :data_processing_consent, acceptance: true, on: %i[contributor_signup update]
 
   validates :email, uniqueness: { case_sensitive: false }, allow_nil: true, 'valid_email_2/email': true
   validates :threema_id, uniqueness: { case_sensitive: false }, allow_blank: true, format: { with: /\A[A-Za-z0-9]+\z/ }, length: { is: 8 }

--- a/app/views/onboarding/threema/show.html.erb
+++ b/app/views/onboarding/threema/show.html.erb
@@ -1,5 +1,5 @@
 <main>
   <%= c 'interstitial' do %>
-    <%= c 'onboarding_threema_form' %>
+    <%= c 'onboarding_threema_form', contributor: @contributor %>
   <% end %>
 </main>

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :contributor do
     first_name { 'John' }
     last_name { 'Doe' }
+    data_processing_consent { true }
     sequence :email do |n|
       "contributor#{n}@example.org"
     end

--- a/spec/requests/onboarding/telegram_spec.rb
+++ b/spec/requests/onboarding/telegram_spec.rb
@@ -158,6 +158,8 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
 
   describe 'PATCH /onboarding/telegram' do
     let!(:contributor) { create(:contributor, telegram_id: 789, first_name: nil, last_name: nil) }
+    let!(:other_contributor) { create(:contributor, email: 'the@other.de', telegram_id: nil) }
+
     let(:attrs) do
       {
         first_name: 'Update',
@@ -180,6 +182,11 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
           contributor = Contributor.find_by(telegram_id: 789)
           expect(contributor).to have_attributes(first_name: nil, last_name: nil)
         end
+
+        it 'does not update other users' do
+          other_contributor = Contributor.find_by(email: 'the@other.de')
+          expect(other_contributor).to have_attributes(first_name: 'John', last_name: 'Doe')
+        end
       end
 
       context 'expired signature' do
@@ -197,7 +204,6 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
       context 'without data processing consent' do
         before { setup_telegram_id_cookie(contributor) }
         let(:data_processing_consent) { false }
-  
         it 'displays validation errors' do
           subject.call
           parsed = Capybara::Node::Simple.new(response.body)
@@ -205,7 +211,6 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
           data_processing_consent_field = fields.find { |f| f.has_text? 'Allgemeine Nutzungsbedingungen' }
           expect(data_processing_consent_field).to have_text('muss akzeptiert werden')
         end
-  
       end
     end
 


### PR DESCRIPTION
This PR adds the following three things:

1. Server-side validation for the data processing consent attribute for contributors
 

2. A fix for a bug that caused the timestamp of data processing consent not being saved for contributors signing up via Telegram

3. A fix for a bug that enabled contributors to update the data of an other contributor if they were signing up via Telegram and updating their data after their telegram_id cookie had expired
