### PR TITLE
Add setting for custom onboarding byline

### DIFF
--- a/app/components/onboarding_header/onboarding_header.html.erb
+++ b/app/components/onboarding_header/onboarding_header.html.erb
@@ -1,13 +1,15 @@
 <header class="<%= class_attr %>">
   <% if logo.present? %>
-    <img src="<%= logo %>" alt="<%= Setting.project_name %>" />
+    <img src="<%= logo %>" alt="<%= project_name %>" />
   <% else %>
     <div class="OnboardingHeader__logoText">
-      <%= Setting.project_name %>
+      <%= project_name %>
     </div>
   <% end %>
 
-  <span class="OnboardingHeader-byline">
-    <%= I18n.t('components.onboarding_header.byline').html_safe %>
-  </span>
+  <% if byline %>
+    <span class="OnboardingHeader-byline">
+      <%= byline %>
+    </span>
+  <% end %>
 </header>

--- a/app/components/onboarding_header/onboarding_header.rb
+++ b/app/components/onboarding_header/onboarding_header.rb
@@ -11,5 +11,13 @@ module OnboardingHeader
     private
 
     attr_reader :logo
+
+    def project_name
+      Setting.project_name
+    end
+
+    def byline
+      Setting.onboarding_byline
+    end
   end
 end

--- a/app/components/settings_form/settings_form.html.erb
+++ b/app/components/settings_form/settings_form.html.erb
@@ -20,6 +20,10 @@
         <%= c 'input', field.input_defaults.merge(type: :url) %>
       <% end %>
 
+      <%= c 'field', object: setting, value: Setting.onboarding_byline, id: :onboarding_byline do |field| %>
+        <%= c 'input', field.input_defaults %>
+      <% end %>
+
       <%= c 'field', object: setting, value: Setting.onboarding_hero, id: :onboarding_hero do |field| %>
         <%= c 'input', field.input_defaults.merge(type: :url) %>
       <% end %>
@@ -27,7 +31,6 @@
       <%= c 'field', object: setting, value: Setting.onboarding_title, id: :onboarding_title do |field| %>
         <%= c 'input', field.input_defaults %>
       <% end %>
-
       <%= c 'field', object: setting, value: Setting.onboarding_page, id: :onboarding_page do |field| %>
         <%= c 'textarea', field.input_defaults %>
       <% end %>

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -20,6 +20,7 @@ class SettingsController < ApplicationController
       :onboarding_logo,
       :onboarding_hero,
       :onboarding_title,
+      :onboarding_byline,
       :onboarding_success_heading,
       :onboarding_success_text,
       :onboarding_unauthorized_heading,

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -10,6 +10,7 @@ class Setting < RailsSettings::Base
   field :onboarding_logo, default: ''
   field :onboarding_hero, default: ''
   field :onboarding_title, default: 'Hallo und herzlich willkommen!'
+  field :onboarding_byline, default: ''
   field :onboarding_page, default: File.read(File.join('config', 'locales', 'onboarding', 'page.md'))
   field :onboarding_success_heading, default: File.read(File.join('config', 'locales', 'onboarding', 'success_heading.txt'))
   field :onboarding_success_text, default: File.read(File.join('config', 'locales', 'onboarding', 'success_text.txt'))

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -79,8 +79,6 @@ de:
           text: 100eyes sammelt alle Antworten und stellt sie dir übersichtlich zur Auswertung dar.
         - icon: app-services
           text: Werte die Antworten mit Hilfe von 100eyes aus und komponiere deine Veröffentlichung.
-    onboarding_header:
-      byline: eine Dialog-Recherche von <a class="Link" href="https://tactile.news" target="_blank">tactile.news</a>
     onboarding_email_form:
       heading: Per E-Mail teilnehmen
       text: Geben Sie bitte unten Ihre Kontaktdaten ein, um Ihre Anmeldung abzuschließen.
@@ -179,6 +177,9 @@ de:
       onboarding_logo:
         label: Logo (URL)
         help: Das Logo sollte eine Bilddatei im SVG-, PNG-Format sein und ca. 90 Pixel hoch sein. Es wird während des Onboardings angezeigt.
+      onboarding_byline:
+        label: Unterzeile
+        help: Wird unter dem Projekttitel bzw. Logo angezeigt.
       onboarding_hero:
         label: Header-Bild (URL)
         help: Das Header-Bild sollte eine Bilddatei im JPEG-Format sein. Es sollte ein Seitenverhältnis von 2:1 haben und ca. 900 Pixel breit sein. Es wird während des Onboardings angezeigt.


### PR DESCRIPTION
This allows editors to customize the byline displayed below the project logo/title (e.g. “eine Dialogrecherche von tactile.news”).

Previously, we also included a (static) link to the publisher’s website, this is not possible anymore. @drjakob approved this change.

Closes #842 

https://user-images.githubusercontent.com/1512805/117886033-eae71b00-b2ae-11eb-9c0f-b50990182c70.mov

