### PR TITLE
Relax Postgres version constraint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk --update add \
     git \
     nodejs \
     yarn \
-    postgresql-dev=~12.6 \
-    postgresql-client=~12.6 \
+    postgresql-dev=~12 \
+    postgresql-client=~12 \
     tzdata \
     libxslt-dev \
     libxml2-dev \


### PR DESCRIPTION
The Alpine package repo only provides the latest minor version of packages, so we regularly run into issues when the Postgres packages get an update and the exact minor version we’re pinning isn’t available anymore.

As far as I know, the Postgres client and client libraries should be compatible with any server of the same major version, so it should be save to relax the version constraint.