### PR TITLE
Make link to data protection statement customisable

### DIFF
--- a/app/components/field/field.rb
+++ b/app/components/field/field.rb
@@ -36,7 +36,7 @@ module Field
 
     def help
       # rubocop:disable Rails/OutputSafety
-      I18n.t("#{type}.form.#{id}.help", default: nil)&.html_safe
+      I18n.t("#{type}.form.#{id}.help", value: value, default: nil)&.html_safe
       # rubocop:enable Rails/OutputSafety
     end
 

--- a/app/components/onboarding_email_form/onboarding_email_form.html.erb
+++ b/app/components/onboarding_email_form/onboarding_email_form.html.erb
@@ -22,7 +22,7 @@
         <%= c 'input', field.input_defaults.merge(placeholder: '', required: true, type: :email) %>
       <% end %>
 
-      <%= c 'field', object: @contributor, id: :data_processing_consent, styles: [:horizontal, :leftAligned] do |field| %>
+      <%= c 'field', object: @contributor, id: :data_processing_consent, value: data_protection_link, styles: [:horizontal, :leftAligned] do |field| %>
         <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
       <% end %>
 

--- a/app/components/onboarding_email_form/onboarding_email_form.rb
+++ b/app/components/onboarding_email_form/onboarding_email_form.rb
@@ -11,7 +11,7 @@ module OnboardingEmailForm
     private
 
     attr_reader :contributor
-    
+
     def data_protection_link
       Setting.onboarding_data_protection_link
     end

--- a/app/components/onboarding_email_form/onboarding_email_form.rb
+++ b/app/components/onboarding_email_form/onboarding_email_form.rb
@@ -11,5 +11,9 @@ module OnboardingEmailForm
     private
 
     attr_reader :contributor
+    
+    def data_protection_link
+      Setting.onboarding_data_protection_link
+    end
   end
 end

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
@@ -20,7 +20,7 @@
 
       <%= c 'input', id: 'contributor[telegram_onboarding_token]', type: 'hidden', value: contributor.telegram_onboarding_token %>
 
-      <%= c 'field', object: contributor, id: :data_processing_consent, styles: [:horizontal, :leftAligned] do |field| %>
+      <%= c 'field', object: contributor, id: :data_processing_consent, value: data_protection_link, styles: [:horizontal, :leftAligned] do |field| %>
         <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
       <% end %>
 

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.rb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.rb
@@ -11,5 +11,9 @@ module OnboardingTelegramForm
     private
 
     attr_reader :contributor
+
+    def data_protection_link
+      Setting.onboarding_data_protection_link
+    end
   end
 end

--- a/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
@@ -22,7 +22,7 @@
         <%= c 'input', field.input_defaults.merge(required: true, pattern: '[A-Za-z0-9]{8}') %>
       <% end %>
 
-      <%= c 'field', object: @contributor, id: :data_processing_consent, styles: [:horizontal, :leftAligned] do |field| %>
+      <%= c 'field', object: @contributor, id: :data_processing_consent, value: data_protection_link, styles: [:horizontal, :leftAligned] do |field| %>
         <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
       <% end %>
 

--- a/app/components/onboarding_threema_form/onboarding_threema_form.rb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.rb
@@ -11,5 +11,9 @@ module OnboardingThreemaForm
     private
 
     attr_reader :contributor
+
+    def data_protection_link
+      Setting.onboarding_data_protection_link
+    end
   end
 end

--- a/app/components/settings_form/settings_form.html.erb
+++ b/app/components/settings_form/settings_form.html.erb
@@ -31,8 +31,13 @@
       <%= c 'field', object: setting, value: Setting.onboarding_title, id: :onboarding_title do |field| %>
         <%= c 'input', field.input_defaults %>
       <% end %>
+
       <%= c 'field', object: setting, value: Setting.onboarding_page, id: :onboarding_page do |field| %>
         <%= c 'textarea', field.input_defaults %>
+      <% end %>
+
+      <%= c 'field', object: setting, value: Setting.onboarding_data_protection_link, id: :onboarding_data_protection_link do |field| %>
+        <%= c 'input', field.input_defaults.merge(type: :url) %>
       <% end %>
     <% end %>
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -26,6 +26,7 @@ class SettingsController < ApplicationController
       :onboarding_unauthorized_heading,
       :onboarding_unauthorized_text,
       :onboarding_page,
+      :onboarding_data_protection_link,
       :telegram_unknown_content_message,
       :telegram_contributor_not_found_message,
       :threema_unknown_content_message

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -17,6 +17,7 @@ class Setting < RailsSettings::Base
   field :onboarding_unauthorized_heading,
         default: File.read(File.join('config', 'locales', 'onboarding', 'unauthorized_heading.txt'))
   field :onboarding_unauthorized_text, default: File.read(File.join('config', 'locales', 'onboarding', 'unauthorized_text.txt'))
+  field :onboarding_data_protection_link, default: 'https://tactile.news/100eyes-datenschutz/'
 
   field :telegram_unknown_content_message, default: File.read(File.join('config', 'locales', 'telegram', 'unknown_content.txt'))
   field :telegram_contributor_not_found_message, default: File.read(File.join('config', 'locales', 'telegram', 'unknown_contributor.txt'))

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -189,6 +189,9 @@ de:
       onboarding_hero:
         label: Header-Bild (URL)
         help: Das Header-Bild sollte eine Bilddatei im JPEG-Format sein. Es sollte ein Seitenverhältnis von 2:1 haben und ca. 900 Pixel breit sein. Es wird während des Onboardings angezeigt.
+      onboarding_data_protection_link:
+        label: Link zur Datenschutzerklärung
+        help: Falls eine projektspezifische Datenschutzerklärung existiert, kann sie hier angegeben werden. Contributor müssen diese während des Onboardingprozesses akzeptieren.
       telegram_unknown_content_message:
         label: Fehler-Nachricht bei unbekannten Inhalten
         help: Wenn ein Mitglied via Telegram Nachrichten versendet, die von 100eyes noch nicht unterstützt werden, erhält es diese Nachricht.
@@ -265,7 +268,7 @@ de:
         label: Aktiv
       data_processing_consent:
         label: Einwilligung zur Datenverarbeitung
-        help: Ich habe die <a class="Link" href="https://tactile.news/100eyes-datenschutz/" target="_blank">Datenschutzerklärung</a> zur Kenntnis genommen und bin mit deren Geltung einverstanden. In unserer Datenschutzerklärung ist erklärt, welche Tools wir nutzen und mit welchen Firmen wir zusammenarbeiten.
+        help: Ich habe die <a class="Link" href=%{value} target="_blank">Datenschutzerklärung</a> zur Kenntnis genommen und bin mit deren Geltung einverstanden. In unserer Datenschutzerklärung ist erklärt, welche Tools wir nutzen und mit welchen Firmen wir zusammenarbeiten.
   request:
     request:
       one: Frage

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -191,7 +191,7 @@ de:
         help: Das Header-Bild sollte eine Bilddatei im JPEG-Format sein. Es sollte ein Seitenverhältnis von 2:1 haben und ca. 900 Pixel breit sein. Es wird während des Onboardings angezeigt.
       onboarding_data_protection_link:
         label: Link zur Datenschutzerklärung
-        help: Falls eine projektspezifische Datenschutzerklärung existiert, kann sie hier angegeben werden. Contributor müssen diese während des Onboardingprozesses akzeptieren.
+        help: Falls eine projektspezifische Datenschutzerklärung existiert, kannst du sie hier angegeben. Mitglieder müssen diese während des Onboarding-Prozesses akzeptieren.
       telegram_unknown_content_message:
         label: Fehler-Nachricht bei unbekannten Inhalten
         help: Wenn ein Mitglied via Telegram Nachrichten versendet, die von 100eyes noch nicht unterstützt werden, erhält es diese Nachricht.

--- a/spec/components/onboarding_telegram_form_spec.rb
+++ b/spec/components/onboarding_telegram_form_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe OnboardingEmailForm::OnboardingEmailForm, type: :component do
+RSpec.describe OnboardingTelegramForm::OnboardingTelegramForm, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) { build(:contributor) }
   let(:params) { { contributor: contributor, jwt: 'JWT' } }
 
-  it { should have_css('.OnboardingEmailForm') }
+  it { should have_css('.OnboardingTelegramForm') }
   it { should have_link(href: Setting.onboarding_data_protection_link) }
 end

--- a/spec/components/onboarding_threema_form_spec.rb
+++ b/spec/components/onboarding_threema_form_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe OnboardingEmailForm::OnboardingEmailForm, type: :component do
+RSpec.describe OnboardingThreemaForm::OnboardingThreemaForm, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) { build(:contributor) }
   let(:params) { { contributor: contributor, jwt: 'JWT' } }
 
-  it { should have_css('.OnboardingEmailForm') }
+  it { should have_css('.OnboardingThreemaForm') }
   it { should have_link(href: Setting.onboarding_data_protection_link) }
 end


### PR DESCRIPTION
This PR adds a field to the settings page in which users can update the link to the data protection statement, which contributors have to accept in the onboarding process. 

<img width="890" alt="image" src="https://user-images.githubusercontent.com/34538290/120215183-b921fe00-c235-11eb-96e8-e5698908f872.png">


