### PR TITLE
Fix Ansible deployment

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -11,9 +11,11 @@
   collections:
     - devsec.hardening
   roles:
-    - role: initial_setup
     - role: devsec.hardening.ssh_hardening
     - role: devsec.hardening.os_hardening
+      vars:
+        ufw_enable_ipv6: false
+    - role: initial_setup
     - role: gantsign.inotify
       inotify_max_user_watches: 524288
     - role: geerlingguy.pip


### PR DESCRIPTION
The `dev-sec/os-hardening` role changed a UFW default causing IPv6 to be enabled by default. Our DO hosts don’t have IPv6 addresses, resulting in errors during deployment.

As the UFW defaults are set in the `os-hardening` role, we needed to change the execution order of roles, i.e. the `os-hardening` roles is now executed before the `initial_setup ` role.