### PR TITLE
Fix controller bug when updating contributor with invalid values

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -37,7 +37,10 @@ class ContributorsController < ApplicationController
   end
 
   def update
+    @contributors = Contributor.with_attached_avatar
+
     @contributor.editor_guarantees_data_consent = true
+
     if @contributor.update(contributor_params)
       redirect_to contributor_url, flash: { success: I18n.t('contributor.saved', name: @contributor.name) }
     else

--- a/spec/requests/contributors_spec.rb
+++ b/spec/requests/contributors_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe '/contributors', type: :request do
         expect { subject.call }.to_not(change { contributor.data_processing_consent })
       end
     end
+
+    context 'with validations failing' do
+      let(:new_attrs) { { email: 'INVALID' } }
+
+      it do
+        subject.call
+
+        parsed = Capybara::Node::Simple.new(response.body)
+        text = I18n.t('contributor.invalid', name: contributor.name)
+
+        expect(parsed).to have_css('.Notification', text: text)
+      end
+    end
   end
 
   describe 'DELETE /destroy' do


### PR DESCRIPTION
I discovered this bug that I probably introduced when adding the new contributors layout. When updating a contributor with invalid values, `@contributors` was not set which led to an error when rendering the view. This only happened when updating a contributor with invalid values because we redirect on successful form submissions.