### PR TITLE
build(ci): avoid concurrent deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,7 @@ jobs:
   deploy:
     needs: [docker_push]
     runs-on: ubuntu-latest
+    concurrency: staging_environment
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
See:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency

This should fix this problem:

![swappy-20210723_172605](https://user-images.githubusercontent.com/2110676/126805201-803fefeb-2afa-4b08-bc17-166b2f00e912.png)
