### PR TITLE
Polyfill clipboard copy button

### DIFF
--- a/app/components/browser_support_notification/browser_support_notification.html.erb
+++ b/app/components/browser_support_notification/browser_support_notification.html.erb
@@ -1,0 +1,16 @@
+<div
+  <%= attrs %>
+  data-controller="browser-support-notification"
+  hidden
+>
+  <%= c('notification',
+    style: :alert,
+    show_close: false,
+    show_always: true,
+  ) do %>
+    <%= c 'wrapper' do %>
+      <%= t('components.browser_support_notification.message').html_safe %>
+    <% end %>
+  <% end %>
+</div>
+

--- a/app/components/browser_support_notification/browser_support_notification.js
+++ b/app/components/browser_support_notification/browser_support_notification.js
@@ -1,0 +1,16 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  connect() {
+    if (this.isUnsupportedBrowser()) {
+      this.element.hidden = false;
+    }
+  }
+
+  isUnsupportedBrowser() {
+    return (
+      !navigator.userAgent.includes('Firefox') &&
+      !navigator.userAgent.includes('Chrome')
+    );
+  }
+}

--- a/app/components/browser_support_notification/browser_support_notification.rb
+++ b/app/components/browser_support_notification/browser_support_notification.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module BrowserSupportNotification
+  class BrowserSupportNotification < ApplicationComponent; end
+end

--- a/app/components/copy_button/copy_button.js
+++ b/app/components/copy_button/copy_button.js
@@ -61,7 +61,7 @@ export default class extends Controller {
   }
 
   writeToClipboard(text) {
-    navigator.clipboard.writeText(text).then(() => this.onCopy());
+    clipboard.writeText(text).then(() => this.onCopy());
   }
 
   onCopy() {

--- a/app/components/notification/notification.css
+++ b/app/components/notification/notification.css
@@ -37,3 +37,9 @@
   background-color: var(--color-red-lightest);
   border-color: var(--color-red-light);
 }
+
+.Notification--alert {
+  color: var(--color-orange-darkest);
+  background-color: var(--color-orange-lightest);
+  border-color: var(--color-orange);
+}

--- a/app/components/notification/notification.html.erb
+++ b/app/components/notification/notification.html.erb
@@ -1,6 +1,7 @@
 <div
-  class="<%= class_attr %>"
+  <%= attrs %>
   data-controller="notification"
+  data-notification-show-always-value="'<%= show_always ? 'true' : 'false' %>"
 >
   <%= content %>
   <% if show_close %>

--- a/app/components/notification/notification.js
+++ b/app/components/notification/notification.js
@@ -1,8 +1,18 @@
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
+  static values = {
+    showAlways: Boolean,
+  };
+
   connect() {
     document.addEventListener('turbo:before-cache', () => {
+      // Prevent flickering of notifications that are always
+      // displayed, i.e. across page navigations
+      if (this.showAlwaysValue) {
+        return;
+      }
+
       this.close();
     });
   }

--- a/app/components/notification/notification.rb
+++ b/app/components/notification/notification.rb
@@ -2,14 +2,15 @@
 
 module Notification
   class Notification < ApplicationComponent
-    def initialize(show_close: true, **)
+    def initialize(show_close: true, show_always: false, **)
       super
 
       @show_close = show_close
+      @show_always = show_always
     end
 
     private
 
-    attr_reader :show_close
+    attr_reader :show_close, :show_always
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,12 @@
       <%= t 'skip_to_content' %>
     </a>
 
+
     <div class="sticky">
       <%= c 'nav_bar' %>
+
+      <%= c 'browser_support_notification' %>
+
       <% flash.each do |type, message| %>
         <%= c 'notification', styles: [type] do %>
           <%= message %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -149,6 +149,12 @@ de:
         label: Neues Passwort
         help: mindestens 8 Zeichen lang
       submit: Passwort ändern
+    browser_support_notification:
+      message: >
+        Einige Funktionen werden in deinem Browser womöglich nicht unterstützt.
+        Um 100eyes vollständig zu nutzen, verwende eine aktuelle Version von
+        <a class="Link" href="https://mozilla.org/firefox" target="_blank" rel="noreferrer noopener">Mozilla Firefox</a> oder
+        <a class="Link" href="https://google.com/chrome" target="_blank" rel="noreferrer noopener">Google Chrome</a>.
 
   mailer:
     unsubscribe:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.1.4",
     "@rails/webpacker": "5.4.2",
     "@yaireo/tagify": "^3.25.0",
+    "clipboard-polyfill": "^3.0.3",
     "stimulus": "^2.0.0"
   },
   "devDependencies": {

--- a/spec/components/browser_support_notification_spec.rb
+++ b/spec/components/browser_support_notification_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BrowserSupportNotification::BrowserSupportNotification, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { {} }
+  it { should have_css('.Notification', visible: :hidden) }
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,6 +2111,11 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+clipboard-polyfill@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/clipboard-polyfill/-/clipboard-polyfill-3.0.3.tgz#159ea0768e20edc7ffda404bd13c54c73de4ff40"
+  integrity sha512-hts0o01ZkwjA1qHA5gFePzAj/780W7v+eyN3GdaCRyDnapzcPsKRV5aodv77gcr40NDIcyNjNmc+HvfKV+jD0g==
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"


### PR DESCRIPTION
We had editors using older versions of Safari who wondered why copy buttons didn’t work in their browser. While we officially do only support the latest version of desktop Firefox and Chrome, I fixed this anyways:

* We use the copy button in contributor-facing parts of the application where we have higher requirements regarding cross-browser compatibility.
* It was easy to fix using a polyfill that falls back to older browser APIs.

I also added a warning in browser other than Firefox and Chrome. I did this primarily because it could potentially save us and editors time when trying to figure out why something isn’t working. The browser detection isn’t perfect, e.g. the warning wouldn’t be shown in old, unsupported version of Firefox and Chrome as it only checks for the browser vendor name.

<img width="1227" alt="Screen Shot 2021-08-30 at 11 34 31" src="https://user-images.githubusercontent.com/1512805/131319152-0f2fafc5-522a-48ef-a95f-420fefba5520.png">