### PR TITLE
Update `Contributor.telegram?` to return true with uncomplete onboarding

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -90,7 +90,7 @@ class Contributor < ApplicationRecord
   end
 
   def telegram?
-    telegram_id.present?
+    telegram_id.present? || telegram_onboarding_token.present?
   end
 
   def email?

--- a/spec/adapters/telegram_adapter/outbound_spec.rb
+++ b/spec/adapters/telegram_adapter/outbound_spec.rb
@@ -15,8 +15,14 @@ RSpec.describe TelegramAdapter::Outbound do
       before { message } # we don't count the extra ::send here
       subject { -> { described_class.send!(message) } }
       it { should enqueue_job(described_class) }
+
       context 'contributor has no telegram_id' do
         let(:contributor) { create(:contributor, telegram_id: nil, email: nil) }
+        it { should_not enqueue_job(described_class) }
+      end
+
+      context 'contributor has telegram_onboarding_token' do
+        let(:contributor) { create(:contributor, telegram_id: nil, telegram_onboarding_token: nil, email: nil) }
         it { should_not enqueue_job(described_class) }
       end
     end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -171,6 +171,11 @@ RSpec.describe Contributor, type: :model do
   describe '#telegram?' do
     subject { contributor.telegram? }
 
+    describe 'given a contributor with a telegram onboarding token' do
+      let(:contributor) { create(:contributor, telegram_id: nil, telegram_onboarding_token: 'ABC') }
+      it { should be(true) }
+    end
+
     describe 'given a contributor with a telegram_id and telegram_id' do
       let(:contributor) { create(:contributor, telegram_id: '123') }
       it { should be(true) }


### PR DESCRIPTION
This will display "via Telegram" for contributors who haven’t completed the last step of the Telegram onboarding process. We should also display a warning so editors are aware that the contributor hasn’t yet complete the process (see #1004).

Close #1039