### PR TITLE
Remove required validation for OTP field

### DIFF
--- a/app/components/otp_field/otp_field.html.erb
+++ b/app/components/otp_field/otp_field.html.erb
@@ -3,5 +3,5 @@
   help: t('.help'),
   **attrs
 ) do %>
-  <%= c 'input', required: true, **attrs.slice(:id) %>
+  <%= c 'input', **attrs.slice(:id) %>
 <% end %>


### PR DESCRIPTION
This is a temporary fix while we don’t have a true two-step sign-in flow.