### PR TITLE
Calculate correct count of contributors per tag

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
   Max: 29
 
 Metrics/ClassLength:
-  Max: 116
+  Max: 122
 
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -43,15 +43,21 @@ class Contributor < ApplicationRecord
   end
 
   def self.all_tags_with_count
-    Contributor.all_tags.map do |tag|
-      {
-        id: tag.id,
-        name: tag.name,
-        value: tag.name,
-        count: tag.taggings_count,
-        color: Contributor.tag_color_from_id(tag.id)
-      }
-    end
+    ActsAsTaggableOn::Tag
+      .joins(:taggings)
+      .select('tags.id, tags.name, count(taggings.id) as taggings_count')
+      .group('tags.id')
+      .where(taggings: { taggable_type: name })
+      .all
+      .map do |tag|
+        {
+          id: tag.id,
+          name: tag.name,
+          value: tag.name,
+          count: tag.taggings_count,
+          color: Contributor.tag_color_from_id(tag.id)
+        }
+      end
   end
 
   def self.tag_color_from_id(tag_id)

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -229,6 +229,20 @@ RSpec.describe Contributor, type: :model do
     end
   end
 
+  describe '.all_tags_with_count' do
+    subject { Contributor.all_tags_with_count.pluck(:name, :count) }
+
+    context 'given a contributor with a tag' do
+      let!(:contributor) { create(:contributor, tag_list: %w[Homeowner]) }
+      it { should eq([['Homeowner', 1]]) }
+
+      context 'and a request with the same tag' do
+        let!(:request) { create(:request, tag_list: %w[Homeowner]) }
+        it { should eq([['Homeowner', 1]]) }
+      end
+    end
+  end
+
   describe '#conversation_about' do
     subject { contributor.conversation_about(the_request) }
 


### PR DESCRIPTION
Previously, we used the precalculated value of the `taggings_count` column. However, this count includes any record tagged with a tag, i.e. also e.g. requests. We’re interested in the number of contributors with a specific tag, though.

Close #1051