### PR TITLE
fix: ignore and remove server.pid in docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN apk --update add \
     less \
     libsodium
 
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
 RUN mkdir -p /app
 WORKDIR /app
 CMD ["bundle", "exec", "rails", "server"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /app/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"
+


### PR DESCRIPTION
See: https://docs.docker.com/samples/rails/#define-the-project

fix: #1028