### PR TITLE
Allow users to move non-broadcasted messages

### DIFF
--- a/app/components/chat_message/chat_message.html.erb
+++ b/app/components/chat_message/chat_message.html.erb
@@ -68,12 +68,13 @@
           </span>
         <% end %>
 
-        <% if message.reply? %>
+        <% unless message.broadcasted? %>
           <%= c 'button', style: :inline, link: move_link do %>
             <%= c 'icon', icon: 'direction-right', style: :inline %>
             <%= I18n.t('components.chat_message.move') %>
           <% end %>
         <% end %>
+        
       <% end %>
     </div>
 

--- a/spec/components/chat_message_spec.rb
+++ b/spec/components/chat_message_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ChatMessage::ChatMessage, type: :component do
 
   describe 'move action' do
     context 'given an inbound message' do
-      let(:message) { create(:message) }
+      let(:message) { create(:message, :with_sender) }
 
       it 'is present' do
         expect(subject).to have_css('a', text: I18n.t('components.chat_message.move'))
@@ -39,10 +39,20 @@ RSpec.describe ChatMessage::ChatMessage, type: :component do
     end
 
     context 'given an outbound message' do
-      let(:message) { create(:message, sender: nil) }
+      context 'with a direct enquiry to a contributor from a user' do
+        let(:message) { create(:message, :with_recipient) }
 
-      it 'is hidden' do
-        expect(subject).to_not have_css('a', text: I18n.t('components.chat_message.move'))
+        it 'is present' do
+          expect(subject).to have_css('a', text: I18n.t('components.chat_message.move'))
+        end
+      end
+
+      context 'with a broadcasted message' do
+        let(:message) { create(:message, :with_recipient, broadcasted: true) }
+
+        it 'is hidden' do
+          expect(subject).to_not have_css('a', text: I18n.t('components.chat_message.move'))
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #1036.

Users can now move all messages except broadcasted ones. 
Broadcasted messages belong to a request and therefore shouldn't be moved.