### PR TITLE
1076 enable signal onboarding

### DIFF
--- a/app/components/onboarding_channel_buttons/onboarding_channel_buttons.css
+++ b/app/components/onboarding_channel_buttons/onboarding_channel_buttons.css
@@ -1,0 +1,15 @@
+.OnboardingChannelButtons {
+  display: grid;
+  gap: var(--spacing-unit);
+  grid-template-columns: 1fr;
+}
+
+@media screen and (min-width: 640px) {
+  .OnboardingChannelButtons {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .OnboardingChannelButtons--even {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/app/components/onboarding_channel_buttons/onboarding_channel_buttons.html.erb
+++ b/app/components/onboarding_channel_buttons/onboarding_channel_buttons.html.erb
@@ -1,0 +1,27 @@
+<div <%= attrs %>>
+  <%= c 'button',
+    link: onboarding_threema_path,
+    label: 'Threema',
+    styles: [:block, :primary, :threema]
+  %>
+
+  <% if show_signal? %>
+    <%= c 'button',
+      link: onboarding_signal_path,
+      label: 'Signal',
+      styles: [:block, :primary, :signal]
+    %>
+  <% end %>
+
+  <%= c 'button',
+    link: onboarding_telegram_path,
+    label: 'Telegram',
+    styles: [:block, :primary, :telegram]
+  %>
+
+  <%= c 'button',
+    link: onboarding_email_path,
+    label: 'E-Mail',
+    styles: [:block, :primary, :email]
+  %>
+</div>

--- a/app/components/onboarding_channel_buttons/onboarding_channel_buttons.rb
+++ b/app/components/onboarding_channel_buttons/onboarding_channel_buttons.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module OnboardingChannelButtons
+  class OnboardingChannelButtons < ApplicationComponent
+    private
+
+    def styles
+      return super unless show_signal?
+
+      super + [:even]
+    end
+
+    def show_signal?
+      Setting.signal_server_phone_number.present?
+    end
+  end
+end

--- a/app/controllers/onboarding/signal_controller.rb
+++ b/app/controllers/onboarding/signal_controller.rb
@@ -3,6 +3,7 @@
 module Onboarding
   class SignalController < OnboardingController
     skip_before_action :verify_jwt, only: :link
+    before_action :ensure_signal_is_set_up
 
     def link; end
 
@@ -14,6 +15,12 @@ module Onboarding
 
     def redirect_to_success
       redirect_to onboarding_signal_link_path(jwt: nil)
+    end
+
+    def ensure_signal_is_set_up
+      return if Setting.signal_server_phone_number.present?
+
+      raise ActionController::RoutingError, 'Not Found'
     end
   end
 end

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -23,33 +23,7 @@
           <%= c 'markdown', raw: Setting.onboarding_page %>
         </div>
 
-        <%= c 'flex' do %>
-          <%= c 'button',
-            link: onboarding_threema_path,
-            label: 'Threema',
-            styles: [:block, :primary, :threema]
-          %>
-          
-          <%= c 'button',
-            link: onboarding_telegram_path,
-            label: 'Telegram',
-            styles: [:block, :primary, :telegram]
-          %>
-
-          <%= c 'button',
-            link: onboarding_email_path,
-            label: 'E-Mail',
-            styles: [:block, :primary, :email]
-          %>
-
-          <!--
-            <%= c 'button',
-              link: onboarding_signal_path,
-              label: 'Signal',
-              styles: [:block, :primary, :signal]
-            %>
-          -->
-        <% end %>
+        <%= c 'onboarding_channel_buttons' %>
 
       <% end %>
     <% end %>

--- a/spec/components/onboarding_channel_buttons_spec.rb
+++ b/spec/components/onboarding_channel_buttons_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OnboardingChannelButtons::OnboardingChannelButtons, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:params) { {} }
+  let(:phone_number) { nil }
+
+  before(:each) { allow(Setting).to receive(:signal_server_phone_number).and_return(phone_number) }
+
+  it { should_not have_css('.OnboardingChannelButtons--even') }
+  it { should have_css('.Button').exactly(3).times }
+
+  context 'if Signal is set up' do
+    let(:phone_number) { '+491234567890' }
+
+    it { should have_css('.Button').exactly(4).times }
+    it { should have_css('.OnboardingChannelButtons--even') }
+  end
+end


### PR DESCRIPTION
| Mobile Layout | Desktop Layout |
|-|-|
![Screen Shot 2021-09-27 at 22 46 56](https://user-images.githubusercontent.com/1512805/134982924-fe12f369-9d34-4c68-b42e-974d77c48b35.png) | <img width="1162" alt="Screen Shot 2021-09-27 at 22 46 44" src="https://user-images.githubusercontent.com/1512805/134982950-6d93da8c-49b7-46b0-ae7c-0b673a6c61b1.png"> |

Close #1076 