### PR TITLE
Set onboarding token / link validity to one year

### DIFF
--- a/app/controllers/concerns/jwt_helper.rb
+++ b/app/controllers/concerns/jwt_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module JwtHelper
-  def create_jwt(payload, expires_in: 7.days.from_now.to_i)
+  def create_jwt(payload, expires_in: 1.year.from_now.to_i)
     JsonWebToken.encode(payload, expires_in: expires_in)
   end
 end

--- a/app/models/json_web_token.rb
+++ b/app/models/json_web_token.rb
@@ -5,7 +5,7 @@ class JsonWebToken < ApplicationRecord
 
   belongs_to :contributor, optional: true
 
-  def self.encode(payload, expires_in: 7.days.from_now.to_i)
+  def self.encode(payload, expires_in: 1.year.from_now.to_i)
     expires_in_payload = { data: payload, exp: expires_in }
     JWT.encode(expires_in_payload, SECRET_KEY, 'HS256')
   end

--- a/spec/models/json_web_token_spec.rb
+++ b/spec/models/json_web_token_spec.rb
@@ -5,16 +5,15 @@ require 'rails_helper'
 RSpec.describe JsonWebToken, type: :model do
   let(:secret_key) { Rails.application.secrets.secret_key_base.to_s }
   let(:algorithm) { 'HS256' }
-  let!(:valid_jwt) { JWT.encode({ data: payload, exp: 7.days.from_now.to_i }, secret_key, 'HS256') }
+  let!(:valid_jwt) { JWT.encode({ data: payload, exp: 1.year.from_now.to_i }, secret_key, 'HS256') }
   let(:payload) { { invite_code: SecureRandom.base64(16), action: 'onboarding' } }
 
   describe '.encode(payload)' do
     let(:jwt_mock) { double('Ruby JWT', encode: valid_jwt) }
 
     context 'Default' do
-      it 'creates a jwt that expires in one week' do
-        expect(JWT).to receive(:encode).with({ data: payload, exp: 7.days.from_now.to_i }, secret_key, algorithm).and_return(:jwt_mock)
-
+      it 'creates a jwt that expires in one year' do
+        expect(JWT).to receive(:encode).with({ data: payload, exp: 1.year.from_now.to_i }, secret_key, algorithm).and_return(:jwt_mock)
         described_class.encode(payload)
       end
     end
@@ -38,7 +37,7 @@ RSpec.describe JsonWebToken, type: :model do
           'invite_code' => 'NrzYTJqq+MI+e2Gen6lDVg==',
           'action' => 'onboarding'
         },
-        'exp' => 7.days.from_now.to_i
+        'exp' => 1.year.from_now.to_i
       },
        { 'alg' => 'HS256' }]
     end
@@ -53,7 +52,7 @@ RSpec.describe JsonWebToken, type: :model do
 
     context 'Invalid token' do
       it 'expired' do
-        passed_expiration_time = 7.days.from_now + 1.minute
+        passed_expiration_time = 1.year.from_now + 1.minute
 
         Timecop.travel(passed_expiration_time) do
           expect { described_class.decode(valid_jwt) }.to raise_error(JWT::ExpiredSignature)
@@ -61,7 +60,7 @@ RSpec.describe JsonWebToken, type: :model do
       end
 
       context 'unsigned token' do
-        let(:unsigned_token) { JWT.encode({ data: payload, exp: 7.days.from_now.to_i }, 'some other signature', 'HS256') }
+        let(:unsigned_token) { JWT.encode({ data: payload, exp: 1.year.from_now.to_i }, 'some other signature', 'HS256') }
 
         it 'invalid token' do
           expect { described_class.decode(unsigned_token) }.to raise_error(JWT::DecodeError)


### PR DESCRIPTION
Closes #1111.

I found some refactoring worthy code in the JWT implementation, which I did not have the time to do for now. See the tracker issue: #1127. 