### PR TITLE
build: exclude build/ folder from prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "build:css": "postcss ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.css",
     "build:js": "bin/esbuild",
     "build": "run-p -l 'build:** --watch'",
-    "prettier": "prettier --check 'app/**/*.{js,css}'",
-    "prettier:fix": "prettier --write 'app/**/*.{js,css}'"
+    "prettier": "prettier --check 'app/**/!(build)/*.{js,css}'",
+    "prettier:fix": "prettier --write 'app/**/!(build)/*.{js,css}'"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",


### PR DESCRIPTION
That was quite annoying. Not seeing any code changes after `yarn run
prettier:fix`, yet not being able to push the commits.