### PR TITLE
Improve readability of phone number during Signal onboardinig

### DIFF
--- a/app/components/onboarding_signal_link/onboarding_signal_link.html.erb
+++ b/app/components/onboarding_signal_link/onboarding_signal_link.html.erb
@@ -10,7 +10,9 @@
     </p>
 
     <p>
-      <%= t('components.onboarding_signal_link.action', number: Setting.signal_server_phone_number).html_safe %>
+      <%= t('components.onboarding_signal_link.action',
+        number: Setting.signal_server_phone_number.phony_formatted(spaces: ' ')
+      ).html_safe %>
     </p>
   <% end %>
 

--- a/spec/components/onboarding_signal_link_spec.rb
+++ b/spec/components/onboarding_signal_link_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe OnboardingSignalLink::OnboardingSignalLink, type: :component do
   subject { render_inline(described_class.new(**params)) }
-
   let(:params) { {} }
+  before(:each) { allow(Setting).to receive(:signal_server_phone_number).and_return('+4915112345678') }
+
   it { should have_css('.OnboardingSignalLink') }
+
+  # \u00a0 is a non-breaking space
+  it { should have_css('strong', text: "0151\u00a01234\u00a05678") }
 end


### PR DESCRIPTION
This is one of the subtasks from the Signal follow-up ticket.

| Before | After |
|-|-|
|![Screen Shot 2021-11-20 at 12 38 50](https://user-images.githubusercontent.com/1512805/142724981-f4ce2abe-a37c-4c4b-85e1-2972b86354ae.png)|![Screen Shot 2021-11-20 at 12 38 35](https://user-images.githubusercontent.com/1512805/142724987-6389b34e-d926-43aa-8186-ebb6ba1242f3.png)|