### PR TITLE
Fix CSS gradient in two column layout in Safari

### DIFF
--- a/app/components/two_column_layout/two_column_layout.css
+++ b/app/components/two_column_layout/two_column_layout.css
@@ -34,7 +34,7 @@
 
   background-image: linear-gradient(
     to bottom,
-    transparent,
+    rgba(255, 255, 255, 0),
     var(--color-gray-lightest) 90%
   );
 }


### PR DESCRIPTION
This fixes a minor rendering bug in Safari. While we don’t officially support Safari, it’s a one-line change and this has constantly annoyed me.

https://stackoverflow.com/questions/11829410/css3-gradient-rendering-issues-from-transparent-to-white

<img width="367" alt="Screen Shot 2021-11-20 at 12 46 10" src="https://user-images.githubusercontent.com/1512805/142725301-f60a1552-59ff-46d9-9473-225a2e122a3c.png">