### PR TITLE
Add support for Signal reaction emojis

### DIFF
--- a/app/adapters/signal_adapter/inbound.rb
+++ b/app/adapters/signal_adapter/inbound.rb
@@ -6,7 +6,7 @@ module SignalAdapter
   CONNECT = :connect
 
   class Inbound
-    UNKNOWN_CONTENT_KEYS = %w[mentions contacts reaction sticker].freeze
+    UNKNOWN_CONTENT_KEYS = %w[mentions contacts sticker].freeze
     SUPPORTED_ATTACHMENT_TYPES = %w[image/jpg image/jpeg image/png image/gif audio/oog audio/aac audio/mp4].freeze
 
     attr_reader :sender, :text, :message
@@ -68,7 +68,12 @@ module SignalAdapter
 
       data_message = signal_message.dig(:envelope, :dataMessage)
 
-      message = Message.new(text: data_message[:message], sender: sender)
+      reaction = data_message[:reaction]
+      return nil if reaction && reaction[:isRemove]
+
+      message_text = reaction ? reaction[:emoji] : data_message[:message]
+
+      message = Message.new(text: message_text, sender: sender)
       message.raw_data.attach(
         io: StringIO.new(JSON.generate(signal_message)),
         filename: 'signal_message.json',

--- a/app/adapters/signal_adapter/inbound.rb
+++ b/app/adapters/signal_adapter/inbound.rb
@@ -64,12 +64,11 @@ module SignalAdapter
 
     def initialize_message(signal_message)
       is_receipt = signal_message.dig(:envelope, :receiptMessage)
-      return nil if is_receipt
+      is_remove_emoji = signal_message.dig(:envelope, :dataMessage, :reaction, :isRemove)
+      return nil if is_receipt || is_remove_emoji
 
       data_message = signal_message.dig(:envelope, :dataMessage)
-
       reaction = data_message[:reaction]
-      return nil if reaction && reaction[:isRemove]
 
       message_text = reaction ? reaction[:emoji] : data_message[:message]
 

--- a/spec/support/matchers/have_current_user.rb
+++ b/spec/support/matchers/have_current_user.rb
@@ -11,7 +11,7 @@ RSpec::Matchers.define :have_current_user do |user|
     "have current user #{user&.id}"
   end
 
-  failure_message_for_should do |_response|
+  failure_message do |_response|
     "have current user #{user&.id}, but got #{user&.id}"
   end
 


### PR DESCRIPTION
This is a PR for the Signal Follow-Up Improvement (#1055) **Handle emoji reactions** and issue **Signal emoji fix** (#1144).

@FrauCsu asked to prioritise this improvement.

<img width="289" alt="image" src="https://user-images.githubusercontent.com/34538290/139528598-53066c70-e6b8-44f0-bf64-9a85d15b5bf0.png">

Signal allows users to react to messages with emojis (like e.g. the heart emoji in the screenshot above). These emojis are then displayed together with the message. We previously did not support reaction emojis and sent an `UNKNOWN_CONTENT` message to contributors who used reaction emojis.

This PR now implements the following logic for supporting signal reaction emojis:

- Each reaction emoji gets stored and displayed as a separate message from the contributor containing only the reaction emoji. [1]
- If a contributor changes her or his reaction emoji the new emoji gets stored and displayed in an additional message [2]
- If a contributor deletes a reaction emoji this is not registered / handled. [3]

[1]: **Displaying reaction emoji**
  - <img width="503" alt="image" src="https://user-images.githubusercontent.com/34538290/143086555-67311bf4-567e-424f-bede-33959383104c.png">
  - <img width="508" alt="image" src="https://user-images.githubusercontent.com/34538290/143086598-7dec38b1-185b-4416-b3e3-185253fafa33.png">

[2]: **Displaying changed reaction emoji**
  - <img width="505" alt="image" src="https://user-images.githubusercontent.com/34538290/143086631-0b3c3c90-4df3-410f-9366-1f1197ddc3e3.png">
  - <img width="510" alt="image" src="https://user-images.githubusercontent.com/34538290/143086652-e49a7557-f4df-4a05-8418-7ed6d6643b80.png">
  
[3]: **(Not) displaying removed reaction emoji**
- <img width="510" alt="image" src="https://user-images.githubusercontent.com/34538290/143086697-b906afdc-061c-4010-9235-5c081c2eff71.png">
- <img width="548" alt="image" src="https://user-images.githubusercontent.com/34538290/143086727-db98450b-0801-4f47-83f7-9f313a01fb02.png">



Closes #1144.