### PR TITLE
Run dependabot checks weekly instead of daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,19 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
 
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
 
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
 
-- package-ecosystem: "github-actions"
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: weekly


### PR DESCRIPTION
Running daily Dependabot checks isn't necessary. In case of critical updates, Dependabot/GitHub will notify us anyways. Most of the updates we see are from dependencies with very frequent releases and few changes per release, thus causing a lot of noise.