### PR TITLE
Do not load view_component engine manually

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,6 @@ require 'action_view/railtie'
 # require "action_cable/engine"
 require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
-require 'view_component/engine'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
This is deprecated:

> DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"`. (called from <main> at /app/config/application.rb:19)