### PR TITLE
Set human-readable server name in sentry config

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,4 +3,5 @@
 Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger]
   config.capture_exception_frame_locals = true
+  config.server_name = ENV['APPLICATION_HOSTNAME'] if ENV['APPLICATION_HOSTNAME'].present?
 end


### PR DESCRIPTION
This displays a human-readable server name (based on the application host name) in Sentry that allows for easier debugging:

| Before | After |
| - | - |
| <img width="848" alt="Screen Shot 2022-01-24 at 13 11 00" src="https://user-images.githubusercontent.com/1512805/150780772-0e1abc4a-7a4a-46bc-8ee8-d03ac6a912b9.png"> | <img width="876" alt="Screen Shot 2022-01-24 at 13 06 17" src="https://user-images.githubusercontent.com/1512805/150780238-10fdc7ac-29b4-45e6-a8af-da817fcb0759.png"> |

Fix #1192