### PR TITLE
Update generate_config.sh and ansible backup role.

### DIFF
--- a/ansible/roles/backup/tasks/main.yml
+++ b/ansible/roles/backup/tasks/main.yml
@@ -45,12 +45,34 @@
     path: /home/ansible/storage
     dest: /tmp/100eyes-storage.tgz
 
+# As for some instances downloading big archives can fail due to not enough memory,
+# make storage archive accesible as non-root user which halfs the necessary memory
+# for downloading it.
+# https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fetch_module.html#notes
+
+- name: Make storage archive read accessible for all users.
+  ansible.builtin.file:
+    path: /tmp/100eyes-storage.tgz
+    mode: '0444'
+
 - name: Download database dump
   fetch:
     src: /tmp/100eyes-db-dump
     dest: "{{ backup_directory }}"
+  become: no
 
 - name: Download storage archive
   fetch:
     src: /tmp/100eyes-storage.tgz
     dest: "{{ backup_directory }}"
+  become: no
+
+- name: Remove database dump
+  ansible.builtin.file:
+    path: /tmp/100eyes-db-dump
+    state: absent
+
+- name: Remove storage archive
+  ansible.builtin.file:
+    path: /tmp/100eyes-storage.tgz
+    state: absent


### PR DESCRIPTION

- For compatability with MacOS generate_config.sh now checks on the OS and uses gtr instead of tr.
- Backup role now downloads the storage archive and database dump as a non-root user to decrease overall needed memory. (Not enough memory sometimes let a download fail.)