### PR TITLE
Add additional consent checkbox

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
   Max: 29
 
 Metrics/ClassLength:
-  Max: 131
+  Max: 140
 
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.
@@ -23,7 +23,7 @@ Metrics/BlockLength:
 # Offense count: 9
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.

--- a/app/components/checkbox/checkbox.html.erb
+++ b/app/components/checkbox/checkbox.html.erb
@@ -1,7 +1,9 @@
+<input type='hidden' value='0' name="<%= name %>">
 <input
   type="checkbox"
   id="<%= id %>"
   name="<%= name %>"
-  <%= value ? 'checked' : '' %>
+  value='1'
+  <%= checked ? 'checked' : '' %>
   <%= required ? 'required' : '' %>
 />

--- a/app/components/checkbox/checkbox.rb
+++ b/app/components/checkbox/checkbox.rb
@@ -2,10 +2,10 @@
 
 module Checkbox
   class Checkbox < ApplicationComponent
-    def initialize(id: nil, value: nil, group: false, label: nil, required: false, **)
+    def initialize(id: nil, checked: false, group: false, label: nil, required: false, **)
       super
       @id = id
-      @value = value
+      @checked = checked
       @group = group
       @label = label
       @required = required
@@ -19,6 +19,6 @@ module Checkbox
       id
     end
 
-    attr_reader :id, :value, :group, :label, :required
+    attr_reader :id, :checked, :group, :label, :required
   end
 end

--- a/app/components/onboarding_email_form/onboarding_email_form.html.erb
+++ b/app/components/onboarding_email_form/onboarding_email_form.html.erb
@@ -31,13 +31,13 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
-      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
         <%= c('field',
           object: contributor,
           attr: :additional_consent,
           styles: [:horizontal, :leftAligned],
-          label: Setting.additional_consent_heading,
-          help: Setting.additional_consent_text
+          label: Setting.onboarding_additional_consent_heading,
+          help: Setting.onboarding_additional_consent_text
         ) do |field| %>
           <%= c 'checkbox', field.input_defaults %>
         <% end %>

--- a/app/components/onboarding_email_form/onboarding_email_form.html.erb
+++ b/app/components/onboarding_email_form/onboarding_email_form.html.erb
@@ -31,6 +31,18 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
+      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+        <%= c('field',
+          object: contributor,
+          attr: :additional_consent,
+          styles: [:horizontal, :leftAligned],
+          label: Setting.additional_consent_heading,
+          help: Setting.additional_consent_text
+        ) do |field| %>
+          <%= c 'checkbox', field.input_defaults %>
+        <% end %>
+      <% end %>
+
       <%= c 'button',
         type: 'submit',
         label: I18n.t('components.onboarding_email_form.submit'),

--- a/app/components/onboarding_signal_form/onboarding_signal_form.html.erb
+++ b/app/components/onboarding_signal_form/onboarding_signal_form.html.erb
@@ -31,6 +31,18 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
+      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+        <%= c('field',
+          object: contributor,
+          attr: :additional_consent,
+          styles: [:horizontal, :leftAligned],
+          label: Setting.additional_consent_heading,
+          help: Setting.additional_consent_text
+        ) do |field| %>
+          <%= c 'checkbox', field.input_defaults %>
+        <% end %>
+      <% end %>
+
       <%= c 'button',
         type: 'submit',
         label: I18n.t('components.onboarding_signal_form.submit'),

--- a/app/components/onboarding_signal_form/onboarding_signal_form.html.erb
+++ b/app/components/onboarding_signal_form/onboarding_signal_form.html.erb
@@ -31,13 +31,13 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
-      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
         <%= c('field',
           object: contributor,
           attr: :additional_consent,
           styles: [:horizontal, :leftAligned],
-          label: Setting.additional_consent_heading,
-          help: Setting.additional_consent_text
+          label: Setting.onboarding_additional_consent_heading,
+          help: Setting.onboarding_additional_consent_text
         ) do |field| %>
           <%= c 'checkbox', field.input_defaults %>
         <% end %>

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
@@ -33,6 +33,18 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
+      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+        <%= c('field',
+          object: contributor,
+          attr: :additional_consent,
+          styles: [:horizontal, :leftAligned],
+          label: Setting.additional_consent_heading,
+          help: Setting.additional_consent_text
+        ) do |field| %>
+          <%= c 'checkbox', field.input_defaults %>
+        <% end %>
+      <% end %>
+
       <%= c 'button',
         type: 'submit',
         label: t('components.onboarding_telegram_form.submit'),

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
@@ -33,13 +33,13 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
-      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
         <%= c('field',
           object: contributor,
           attr: :additional_consent,
           styles: [:horizontal, :leftAligned],
-          label: Setting.additional_consent_heading,
-          help: Setting.additional_consent_text
+          label: Setting.onboarding_additional_consent_heading,
+          help: Setting.onboarding_additional_consent_text
         ) do |field| %>
           <%= c 'checkbox', field.input_defaults %>
         <% end %>

--- a/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
@@ -28,7 +28,19 @@
         help: I18n.t('contributor.form.data_processing_consent.help', link: data_protection_link).html_safe,
         style: :leftAligned
       ) do |field| %>
-        <%= c 'checkbox', field.input_defaults.merge(required: true, value: nil) %>
+        <%= c 'checkbox', **field.input_defaults, required: true %>
+      <% end %>
+
+      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+        <%= c('field',
+          object: contributor,
+          attr: :additional_consent,
+          styles: [:horizontal, :leftAligned],
+          label: Setting.additional_consent_heading,
+          help: Setting.additional_consent_text
+        ) do |field| %>
+          <%= c 'checkbox', field.input_defaults %>
+        <% end %>
       <% end %>
 
       <%= c 'button',

--- a/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
@@ -31,13 +31,13 @@
         <%= c 'checkbox', **field.input_defaults, required: true %>
       <% end %>
 
-      <% if Setting.ask_for_additional_consent && Setting.additional_consent_defined %>
+      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
         <%= c('field',
           object: contributor,
           attr: :additional_consent,
           styles: [:horizontal, :leftAligned],
-          label: Setting.additional_consent_heading,
-          help: Setting.additional_consent_text
+          label: Setting.onboarding_additional_consent_heading,
+          help: Setting.onboarding_additional_consent_text
         ) do |field| %>
           <%= c 'checkbox', field.input_defaults %>
         <% end %>

--- a/app/components/settings_form/settings_form.html.erb
+++ b/app/components/settings_form/settings_form.html.erb
@@ -52,17 +52,17 @@
 
       <%= c('field',
         object: setting,
-        attr: :ask_for_additional_consent,
+        attr: :onboarding_ask_for_additional_consent,
         styles: [:horizontal, :leftAligned],
       ) do |field| %>
-        <%= c 'checkbox', **field.input_defaults, checked: Setting.ask_for_additional_consent %>
+        <%= c 'checkbox', **field.input_defaults, checked: Setting.onboarding_ask_for_additional_consent %>
       <% end %>
 
-      <%= c 'field', object: setting, value: Setting.additional_consent_heading, attr: :additional_consent_heading do |field| %>
+      <%= c 'field', object: setting, value: Setting.onboarding_additional_consent_heading, attr: :onboarding_additional_consent_heading do |field| %>
         <%= c 'input', field.input_defaults %>
       <% end %>
 
-      <%= c 'field', object: setting, value: Setting.additional_consent_text, attr: :additional_consent_text do |field| %>
+      <%= c 'field', object: setting, value: Setting.onboarding_additional_consent_text, attr: :onboarding_additional_consent_text do |field| %>
         <%= c 'textarea', field.input_defaults %>
       <% end %>
     <% end %>

--- a/app/components/settings_form/settings_form.html.erb
+++ b/app/components/settings_form/settings_form.html.erb
@@ -47,6 +47,28 @@
 
     <%= c 'stack' do %>
       <%= c 'heading', tag: :h2 do %>
+        <%= t 'setting.form.groups.additional_consent' %>
+      <% end %>
+
+      <%= c('field',
+        object: setting,
+        attr: :ask_for_additional_consent,
+        styles: [:horizontal, :leftAligned],
+      ) do |field| %>
+        <%= c 'checkbox', **field.input_defaults, checked: Setting.ask_for_additional_consent %>
+      <% end %>
+
+      <%= c 'field', object: setting, value: Setting.additional_consent_heading, attr: :additional_consent_heading do |field| %>
+        <%= c 'input', field.input_defaults %>
+      <% end %>
+
+      <%= c 'field', object: setting, value: Setting.additional_consent_text, attr: :additional_consent_text do |field| %>
+        <%= c 'textarea', field.input_defaults %>
+      <% end %>
+    <% end %>
+
+    <%= c 'stack' do %>
+      <%= c 'heading', tag: :h2 do %>
         <%= t 'setting.form.groups.onboarding_success' %>
       <% end %>
 

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -39,11 +39,11 @@ class OnboardingController < ApplicationController
   end
 
   def contributor_params
-    params.require(:contributor).permit(:first_name, :last_name, :data_processing_consent, attr_name)
+    params.require(:contributor).permit(:first_name, :last_name, :data_processing_consent, :additional_consent, attr_name)
   end
 
   def redirect_if_contributor_exists
-    # We handle an onbaording request for a contributor that
+    # We handle an onboarding request for a contributor that
     # already exists in the exact same way as a successful
     # onboarding so that we don't disclose wether someone
     # is a contributor.

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -37,5 +37,4 @@ class SettingsController < ApplicationController
       :threema_unknown_content_message
     )
   end
-
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -16,6 +16,9 @@ class SettingsController < ApplicationController
 
   def settings_params
     params.require(:setting).permit(
+      :ask_for_additional_consent,
+      :additional_consent_heading,
+      :additional_consent_text,
       :project_name,
       :onboarding_logo,
       :onboarding_hero,
@@ -34,4 +37,5 @@ class SettingsController < ApplicationController
       :threema_unknown_content_message
     )
   end
+
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -16,9 +16,9 @@ class SettingsController < ApplicationController
 
   def settings_params
     params.require(:setting).permit(
-      :ask_for_additional_consent,
-      :additional_consent_heading,
-      :additional_consent_text,
+      :onboarding_ask_for_additional_consent,
+      :onboarding_additional_consent_heading,
+      :onboarding_additional_consent_text,
       :project_name,
       :onboarding_logo,
       :onboarding_hero,

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -178,6 +178,6 @@ class Contributor < ApplicationRecord
   def additional_consent?
     additional_consent_given_at.present?
   end
-  
+
   alias additional_consent additional_consent?
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -168,5 +168,16 @@ class Contributor < ApplicationRecord
   def data_processing_consent?
     data_processing_consented_at.present?
   end
+
   alias data_processing_consent data_processing_consent?
+
+  def additional_consent=(value)
+    self.additional_consent_given_at = ActiveModel::Type::Boolean.new.cast(value) ? Time.current : nil
+  end
+
+  def additional_consent?
+    additional_consent_given_at.present?
+  end
+  
+  alias additional_consent additional_consent?
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -6,7 +6,7 @@ class Setting < RailsSettings::Base
 
   class << self
     def additional_consent_defined
-      self.additional_consent_heading.strip.present?
+      additional_consent_heading.strip.present?
     end
   end
 
@@ -56,5 +56,4 @@ class Setting < RailsSettings::Base
 
   field :mailserver_host, readonly: true, default: ENV['MAILSERVER_HOST'] || 'localhost'
   field :mailserver_port, readonly: true, default: ENV['MAILSERVER_PORT'] || 1025
-
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -5,8 +5,8 @@ class Setting < RailsSettings::Base
   cache_prefix { 'v1' }
 
   class << self
-    def additional_consent_defined
-      additional_consent_heading.strip.present?
+    def onboarding_additional_consent_defined?
+      onboarding_additional_consent_heading.strip.present?
     end
   end
 
@@ -29,9 +29,9 @@ class Setting < RailsSettings::Base
   field :onboarding_data_protection_link, default: 'https://tactile.news/100eyes-datenschutz/'
   field :onboarding_imprint_link, default: 'https://tactile.news/impressum/'
 
-  field :ask_for_additional_consent, type: :boolean, default: false
-  field :additional_consent_heading, default: ''
-  field :additional_consent_text, default: ''
+  field :onboarding_ask_for_additional_consent, type: :boolean, default: false
+  field :onboarding_additional_consent_heading, default: ''
+  field :onboarding_additional_consent_text, default: ''
 
   field :telegram_unknown_content_message, default: File.read(File.join('config', 'locales', 'telegram', 'unknown_content.txt'))
   field :telegram_contributor_not_found_message, default: File.read(File.join('config', 'locales', 'telegram', 'unknown_contributor.txt'))

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -4,6 +4,12 @@
 class Setting < RailsSettings::Base
   cache_prefix { 'v1' }
 
+  class << self
+    def additional_consent_defined
+      self.additional_consent_heading.strip.present?
+    end
+  end
+
   field :project_name, default: ENV['HUNDRED_EYES_PROJECT_NAME'] || '100eyes'
   field :application_host, readonly: true, default: ENV['APPLICATION_HOSTNAME'] || 'localhost:3000'
 
@@ -22,6 +28,10 @@ class Setting < RailsSettings::Base
   field :onboarding_unauthorized_text, default: File.read(File.join('config', 'locales', 'onboarding', 'unauthorized_text.txt'))
   field :onboarding_data_protection_link, default: 'https://tactile.news/100eyes-datenschutz/'
   field :onboarding_imprint_link, default: 'https://tactile.news/impressum/'
+
+  field :ask_for_additional_consent, type: :boolean, default: false
+  field :additional_consent_heading, default: ''
+  field :additional_consent_text, default: ''
 
   field :telegram_unknown_content_message, default: File.read(File.join('config', 'locales', 'telegram', 'unknown_content.txt'))
   field :telegram_contributor_not_found_message, default: File.read(File.join('config', 'locales', 'telegram', 'unknown_contributor.txt'))
@@ -46,4 +56,5 @@ class Setting < RailsSettings::Base
 
   field :mailserver_host, readonly: true, default: ENV['MAILSERVER_HOST'] || 'localhost'
   field :mailserver_port, readonly: true, default: ENV['MAILSERVER_PORT'] || 1025
+
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -312,6 +312,14 @@ de:
         onboarding: Onboarding
         onboarding_success: Nachricht nach erfolgreichem Onboarding
         onboarding_unauthorized: Meldung nach erfolglosem Onboarding
+        additional_consent: Zusätzliche Einverständnisfragen während des Onboarding
+      ask_for_additional_consent:
+        label: Nach zusätzlichem Einverständnis während des Onboardings fragen
+        help: Falls aktiviert wird beim Onboarding eine zusätzliche, optionale Checkbox mit der hier konfigurierbaren Überschrift und Text angezeigt.
+      additional_consent_heading:
+        label: Überschrift
+      additional_consent_text:
+        label: Text
       project_name:
         label: Projekt-Name
         help: Der Projekt-Name wird Community-Mitgliedern z.B. während des Onboardings und als Absender von E-Mails angezeigt.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -312,13 +312,13 @@ de:
         onboarding: Onboarding
         onboarding_success: Nachricht nach erfolgreichem Onboarding
         onboarding_unauthorized: Meldung nach erfolglosem Onboarding
-        additional_consent: Zusätzliche Einverständnisfragen während des Onboarding
-      ask_for_additional_consent:
-        label: Nach zusätzlichem Einverständnis während des Onboardings fragen
-        help: Falls aktiviert wird beim Onboarding eine zusätzliche, optionale Checkbox mit der hier konfigurierbaren Überschrift und Text angezeigt.
-      additional_consent_heading:
+        additional_consent: Zusätzliches Einverständnis während des Onboardings
+      onboarding_ask_for_additional_consent:
+        label: Nach zusätzlichem Einverständnis fragen
+        help: Falls aktiviert, wird neuen Community-Mitgliedern eine zusätzliche, optionale Checkbox angezeigt. Diese kannst du beispielsweise nutzen, um das Einverständnis für den Versand von E-Mail-Newslettern o.ä. einzuholen.
+      onboarding_additional_consent_heading:
         label: Überschrift
-      additional_consent_text:
+      onboarding_additional_consent_text:
         label: Text
       project_name:
         label: Projekt-Name

--- a/db/migrate/20220325112312_add_additional_consent_to_contributors.rb
+++ b/db/migrate/20220325112312_add_additional_consent_to_contributors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdditionalConsentToContributors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contributors, :additional_consent_given_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_163538) do
+ActiveRecord::Schema.define(version: 2022_03_25_112312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_163538) do
     t.string "signal_phone_number"
     t.datetime "signal_onboarding_completed_at"
     t.string "additional_email"
+    t.datetime "additional_consent_given_at"
     t.index ["email"], name: "index_contributors_on_email", unique: true
     t.index ["signal_phone_number"], name: "index_contributors_on_signal_phone_number", unique: true
     t.index ["telegram_chat_id"], name: "index_contributors_on_telegram_chat_id", unique: true

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Checkbox::Checkbox, type: :component do
   it { should have_css('input[type="hidden"][value="0"]', visible: false) }
 
   describe 'can be displayed checked and required' do
-    let(:params) { {checked: true, required: true} }
+    let(:params) { { checked: true, required: true } }
     it { should have_css('input[type="checkbox"][value="1"][checked][required]') }
   end
-
 end

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -7,5 +7,15 @@ RSpec.describe Checkbox::Checkbox, type: :component do
 
   let(:params) { {} }
 
-  it { should have_css('input[type="checkbox"]') }
+  it { should have_css('input[type="checkbox"][value="1"]') }
+  # "The HTML specification says unchecked check boxes are not successful, and thus web browsers do not send them. "
+  # To be able to still send newly unchecked boxes a hidden auxiliary input field is introduced.
+  # See: https://apidock.com/rails/ActionView/Helpers/FormHelper/check_box
+  it { should have_css('input[type="hidden"][value="0"]', visible: false) }
+
+  describe 'can be displayed checked and required' do
+    let(:params) { {checked: true, required: true} }
+    it { should have_css('input[type="checkbox"][value="1"][checked][required]') }
+  end
+
 end

--- a/spec/components/onboarding_email_form_spec.rb
+++ b/spec/components/onboarding_email_form_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe OnboardingEmailForm::OnboardingEmailForm, type: :component do
 
   it { should have_css('.OnboardingEmailForm') }
   it { should have_link(href: Setting.onboarding_data_protection_link) }
+
+  describe 'additional consent check box' do
+    before do
+      Setting.ask_for_additional_consent = true
+      Setting.additional_consent_heading = 'Great expectations.'
+    end
+    context 'given a request for additional consent' do
+      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no request for additional consent' do
+      before do
+        Setting.ask_for_additional_consent = false
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no specified additional consent heading' do
+      before do
+        Setting.additional_consent_heading = '  '
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+  end
 end

--- a/spec/components/onboarding_email_form_spec.rb
+++ b/spec/components/onboarding_email_form_spec.rb
@@ -13,24 +13,24 @@ RSpec.describe OnboardingEmailForm::OnboardingEmailForm, type: :component do
 
   describe 'additional consent check box' do
     before do
-      Setting.ask_for_additional_consent = true
-      Setting.additional_consent_heading = 'Great expectations.'
+      Setting.onboarding_ask_for_additional_consent = true
+      Setting.onboarding_additional_consent_heading = 'Great expectations.'
     end
     context 'given a request for additional consent' do
-      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_text(Setting.onboarding_additional_consent_heading) }
       it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no request for additional consent' do
       before do
-        Setting.ask_for_additional_consent = false
+        Setting.onboarding_ask_for_additional_consent = false
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no specified additional consent heading' do
       before do
-        Setting.additional_consent_heading = '  '
+        Setting.onboarding_additional_consent_heading = '  '
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end

--- a/spec/components/onboarding_signal_form_spec.rb
+++ b/spec/components/onboarding_signal_form_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe OnboardingSignalForm::OnboardingSignalForm, type: :component do
 
   it { should have_css('.OnboardingSignalForm') }
   it { should have_link(href: Setting.onboarding_data_protection_link) }
+
+  describe 'additional consent check box' do
+    before do
+      Setting.ask_for_additional_consent = true
+      Setting.additional_consent_heading = 'Great expectations.'
+    end
+    context 'given a request for additional consent' do
+      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no request for additional consent' do
+      before do
+        Setting.ask_for_additional_consent = false
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no specified additional consent heading' do
+      before do
+        Setting.additional_consent_heading = '  '
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+  end
 end

--- a/spec/components/onboarding_signal_form_spec.rb
+++ b/spec/components/onboarding_signal_form_spec.rb
@@ -13,24 +13,24 @@ RSpec.describe OnboardingSignalForm::OnboardingSignalForm, type: :component do
 
   describe 'additional consent check box' do
     before do
-      Setting.ask_for_additional_consent = true
-      Setting.additional_consent_heading = 'Great expectations.'
+      Setting.onboarding_ask_for_additional_consent = true
+      Setting.onboarding_additional_consent_heading = 'Great expectations.'
     end
     context 'given a request for additional consent' do
-      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_text(Setting.onboarding_additional_consent_heading) }
       it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no request for additional consent' do
       before do
-        Setting.ask_for_additional_consent = false
+        Setting.onboarding_ask_for_additional_consent = false
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no specified additional consent heading' do
       before do
-        Setting.additional_consent_heading = '  '
+        Setting.onboarding_additional_consent_heading = '  '
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end

--- a/spec/components/onboarding_telegram_form_spec.rb
+++ b/spec/components/onboarding_telegram_form_spec.rb
@@ -13,24 +13,24 @@ RSpec.describe OnboardingTelegramForm::OnboardingTelegramForm, type: :component 
 
   describe 'additional consent check box' do
     before do
-      Setting.ask_for_additional_consent = true
-      Setting.additional_consent_heading = 'Great expectations.'
+      Setting.onboarding_ask_for_additional_consent = true
+      Setting.onboarding_additional_consent_heading = 'Great expectations.'
     end
     context 'given a request for additional consent' do
-      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_text(Setting.onboarding_additional_consent_heading) }
       it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no request for additional consent' do
       before do
-        Setting.ask_for_additional_consent = false
+        Setting.onboarding_ask_for_additional_consent = false
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no specified additional consent heading' do
       before do
-        Setting.additional_consent_heading = '  '
+        Setting.onboarding_additional_consent_heading = '  '
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end

--- a/spec/components/onboarding_telegram_form_spec.rb
+++ b/spec/components/onboarding_telegram_form_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe OnboardingTelegramForm::OnboardingTelegramForm, type: :component 
 
   it { should have_css('.OnboardingTelegramForm') }
   it { should have_link(href: Setting.onboarding_data_protection_link) }
+
+  describe 'additional consent check box' do
+    before do
+      Setting.ask_for_additional_consent = true
+      Setting.additional_consent_heading = 'Great expectations.'
+    end
+    context 'given a request for additional consent' do
+      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no request for additional consent' do
+      before do
+        Setting.ask_for_additional_consent = false
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no specified additional consent heading' do
+      before do
+        Setting.additional_consent_heading = '  '
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+  end
 end

--- a/spec/components/onboarding_threema_form_spec.rb
+++ b/spec/components/onboarding_threema_form_spec.rb
@@ -13,24 +13,24 @@ RSpec.describe OnboardingThreemaForm::OnboardingThreemaForm, type: :component do
 
   describe 'additional consent check box' do
     before do
-      Setting.ask_for_additional_consent = true
-      Setting.additional_consent_heading = 'Great expectations.'
+      Setting.onboarding_ask_for_additional_consent = true
+      Setting.onboarding_additional_consent_heading = 'Great expectations.'
     end
     context 'given a request for additional consent' do
-      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_text(Setting.onboarding_additional_consent_heading) }
       it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no request for additional consent' do
       before do
-        Setting.ask_for_additional_consent = false
+        Setting.onboarding_ask_for_additional_consent = false
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end
 
     context 'given no specified additional consent heading' do
       before do
-        Setting.additional_consent_heading = '  '
+        Setting.onboarding_additional_consent_heading = '  '
       end
       it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
     end

--- a/spec/components/onboarding_threema_form_spec.rb
+++ b/spec/components/onboarding_threema_form_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe OnboardingThreemaForm::OnboardingThreemaForm, type: :component do
 
   it { should have_css('.OnboardingThreemaForm') }
   it { should have_link(href: Setting.onboarding_data_protection_link) }
+
+  describe 'additional consent check box' do
+    before do
+      Setting.ask_for_additional_consent = true
+      Setting.additional_consent_heading = 'Great expectations.'
+    end
+    context 'given a request for additional consent' do
+      it { should have_text(Setting.additional_consent_heading) }
+      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no request for additional consent' do
+      before do
+        Setting.ask_for_additional_consent = false
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+
+    context 'given no specified additional consent heading' do
+      before do
+        Setting.additional_consent_heading = '  '
+      end
+      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
+    end
+  end
 end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe Contributor, type: :model do
       end
     end
 
-    describe 'given contributor who has not given content' do
+    describe 'given contributor who has not given consent' do
       let(:contributor) { build(:contributor, data_processing_consented_at: nil) }
       describe 'true' do
         it {

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -573,6 +573,47 @@ RSpec.describe Contributor, type: :model do
     end
   end
 
+  describe '.additional_consent' do
+    subject { contributor.additional_consent }
+
+    describe 'given a contributor who has given additional consent' do
+      let(:contributor) { build(:contributor, additional_consent_given_at: 1.day.ago) }
+      it { should be(true) }
+      specify { expect(contributor).to be_valid }
+    end
+
+    describe 'given a contributor who has not given consent' do
+      let(:contributor) { build(:contributor, additional_consent_given_at: nil) }
+      it { should be(false) }
+      specify { expect(contributor).to be_valid }
+    end
+  end
+
+  describe '.additional_consent=' do
+    describe 'given contributor who has given additional consent' do
+      let(:contributor) { create(:contributor, additional_consent: 1.day.ago) }
+      describe 'false' do
+        it { expect { contributor.additional_consent = false }.to change { contributor.additional_consent_given_at }.to(nil) }
+        it { expect { contributor.additional_consent = false }.to change { contributor.additional_consent_given_at? }.to(false) }
+        it { expect { contributor.additional_consent = '0' }.to change { contributor.additional_consent? }.to(false) }
+        it { expect { contributor.additional_consent = 'off' }.to change { contributor.additional_consent? }.to(false) }
+      end
+    end
+
+    describe 'given contributor who has not additional given consent' do
+      let(:contributor) { build(:contributor, additional_consent_given_at: nil) }
+      describe 'true' do
+        it {
+          expect { contributor.additional_consent = true }
+            .to change { contributor.additional_consent_given_at.is_a?(ActiveSupport::TimeWithZone) }.to(true)
+        }
+        it { expect { contributor.additional_consent = true }.to change { contributor.additional_consent? }.to(true) }
+        it { expect { contributor.additional_consent = '1' }.to change { contributor.additional_consent? }.to(true) }
+        it { expect { contributor.additional_consent = 'on' }.to change { contributor.additional_consent? }.to(true) }
+      end
+    end
+  end
+
   describe '.avatar_url=', vcr: { cassette_name: :download_roberts_telegram_profile_picture } do
     let(:url) { 'https://t.me/i/userpic/320/2CixclGZED6EeKGQHKm9wk2v7xKy3LWCJGHJPkgcih0.jpg' }
     subject { -> { contributor.avatar_url = url } }

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -582,7 +582,7 @@ RSpec.describe Contributor, type: :model do
       specify { expect(contributor).to be_valid }
     end
 
-    describe 'given a contributor who has not given consent' do
+    describe 'given a contributor who has not given additional consent' do
       let(:contributor) { build(:contributor, additional_consent_given_at: nil) }
       it { should be(false) }
       specify { expect(contributor).to be_valid }
@@ -600,7 +600,7 @@ RSpec.describe Contributor, type: :model do
       end
     end
 
-    describe 'given contributor who has not additional given consent' do
+    describe 'given contributor who has not given additional consent' do
       let(:contributor) { build(:contributor, additional_consent_given_at: nil) }
       describe 'true' do
         it {

--- a/spec/requests/onboarding/email_spec.rb
+++ b/spec/requests/onboarding/email_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Onboarding::Email', type: :request do
   let(:email) { 'zora@example.org' }
   let(:data_processing_consent) { true }
+  let(:additional_consent) { true }
   let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
   let(:params) { { jwt: jwt } }
 
@@ -14,7 +15,8 @@ RSpec.describe 'Onboarding::Email', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         email: email,
-        data_processing_consent: data_processing_consent
+        data_processing_consent: data_processing_consent,
+        additional_consent: additional_consent
       }
     end
 
@@ -30,7 +32,8 @@ RSpec.describe 'Onboarding::Email', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         email: email,
-        data_processing_consent: data_processing_consent
+        data_processing_consent: data_processing_consent,
+        additional_consent: additional_consent
       )
       expect(contributor.json_web_token).to have_attributes(
         invalidated_jwt: jwt
@@ -96,6 +99,23 @@ RSpec.describe 'Onboarding::Email', type: :request do
       it 'has 422 status code' do
         subject.call
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'without additional consent' do
+      let(:additional_consent) { false }
+
+      it 'creates contributor without additional consent' do
+        expect { subject.call }.to change(Contributor, :count).by(1)
+
+        contributor = Contributor.first
+        expect(contributor).to have_attributes(
+          first_name: 'Zora',
+          last_name: 'Zimmermann',
+          email: email,
+          data_processing_consent: data_processing_consent,
+          additional_consent: additional_consent
+        )
       end
     end
 

--- a/spec/requests/onboarding/signal_spec.rb
+++ b/spec/requests/onboarding/signal_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Onboarding::Signal', type: :request do
   let(:signal_phone_number) { '+4915112345678' }
   let(:data_processing_consent) { true }
+  let(:additional_consent) { true }
   let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
   let(:params) { { jwt: jwt } }
 
@@ -38,7 +39,8 @@ RSpec.describe 'Onboarding::Signal', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         signal_phone_number: signal_phone_number,
-        data_processing_consent: data_processing_consent
+        data_processing_consent: data_processing_consent,
+        additional_consent: additional_consent
       }
     end
 
@@ -56,7 +58,8 @@ RSpec.describe 'Onboarding::Signal', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         signal_phone_number: '+4915112345678',
-        data_processing_consent: true
+        data_processing_consent: data_processing_consent,
+        additional_consent: additional_consent
       )
       expect(contributor.json_web_token).to have_attributes(
         invalidated_jwt: jwt
@@ -134,6 +137,23 @@ RSpec.describe 'Onboarding::Signal', type: :request do
 
       it 'does not create new contributor' do
         expect { subject.call }.not_to change(Contributor, :count)
+      end
+    end
+
+    context 'without additional consent' do
+      let(:additional_consent) { false }
+
+      it 'creates contributor without additional consent' do
+        expect { subject.call }.to change(Contributor, :count).by(1)
+
+        contributor = Contributor.first
+        expect(contributor).to have_attributes(
+          first_name: 'Zora',
+          last_name: 'Zimmermann',
+          signal_phone_number: '+4915112345678',
+          data_processing_consent: data_processing_consent,
+          additional_consent: additional_consent
+        )
       end
     end
 

--- a/spec/requests/onboarding/telegram_spec.rb
+++ b/spec/requests/onboarding/telegram_spec.rb
@@ -28,13 +28,15 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
     let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
     let(:params) { { jwt: jwt } }
     let(:data_processing_consent) { true }
+    let(:additional_consent) { true }
 
     let(:attrs) do
       {
         first_name: 'Zora',
         last_name: 'Zimmermann',
         data_processing_consent: data_processing_consent,
-        telegram_onboarding_token: 'TELEGRAM_ONBOARDING_TOKEN'
+        telegram_onboarding_token: 'TELEGRAM_ONBOARDING_TOKEN',
+        additional_consent: additional_consent
       }
     end
 
@@ -50,7 +52,8 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         data_processing_consent: data_processing_consent,
-        telegram_onboarding_token: 'TELEGRAM_ONBOARDING_TOKEN'
+        telegram_onboarding_token: 'TELEGRAM_ONBOARDING_TOKEN',
+        additional_consent: additional_consent
       )
       expect(contributor.json_web_token).to have_attributes(
         invalidated_jwt: jwt
@@ -89,6 +92,23 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
       it 'has 422 status code' do
         subject.call
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'without additional consent' do
+      let(:additional_consent) { false }
+
+      it 'creates contributor without additional consent' do
+        expect { subject.call }.to change(Contributor, :count).by(1)
+
+        contributor = Contributor.first
+        expect(contributor).to have_attributes(
+          first_name: 'Zora',
+          last_name: 'Zimmermann',
+          data_processing_consent: data_processing_consent,
+          telegram_onboarding_token: 'TELEGRAM_ONBOARDING_TOKEN',
+          additional_consent: additional_consent
+        )
       end
     end
 

--- a/spec/requests/onboarding/threema_spec.rb
+++ b/spec/requests/onboarding/threema_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Onboarding::Threema', type: :request do
   let(:data_processing_consent) { true }
   let(:contributor) { create(:contributor) }
+  let(:additional_consent) { true }
   let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
   let(:params) { { jwt: jwt } }
 
@@ -14,7 +15,8 @@ RSpec.describe 'Onboarding::Threema', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         threema_id: 'ABCD1234',
-        data_processing_consent: data_processing_consent
+        data_processing_consent: data_processing_consent,
+        additional_consent: additional_consent
       }
     end
 
@@ -30,7 +32,8 @@ RSpec.describe 'Onboarding::Threema', type: :request do
         first_name: 'Zora',
         last_name: 'Zimmermann',
         threema_id: 'ABCD1234',
-        data_processing_consent: data_processing_consent
+        data_processing_consent: data_processing_consent,
+        additional_consent: additional_consent
       )
       expect(contributor.json_web_token).to have_attributes(
         invalidated_jwt: jwt
@@ -89,6 +92,23 @@ RSpec.describe 'Onboarding::Threema', type: :request do
       it 'has 422 status code' do
         subject.call
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'without additional consent' do
+      let(:additional_consent) { false }
+
+      it 'creates contributor without additional consent' do
+        expect { subject.call }.to change(Contributor, :count).by(1)
+
+        contributor = Contributor.first
+        expect(contributor).to have_attributes(
+          first_name: 'Zora',
+          last_name: 'Zimmermann',
+          threema_id: 'ABCD1234',
+          data_processing_consent: data_processing_consent,
+          additional_consent: additional_consent
+        )
       end
     end
 


### PR DESCRIPTION
This PR implements basic functionality for configuring an additional consent checkbox as discussed in #1278. 

The additional checkbox can now be configured in Settings and is displayed in the onboarding form for all contributors if displaying the checkbox is activated and a heading for it is configured. (Checkboxes without a configured headline are not displayed.) As discussed the checkbox is always optional and if given the `additional_consent` is stored as a timestamp of the consent time.

Still missing:
- [ ] Displaying / exporting user consent. As a follow-up, a CSV export function should be implemented. It's still to discuss if the given / not given consent should also be displayed on contributor pages.
- [ ] The additional consent text can so far not support pretty links etc. It might be worthwhile to implement it with a `markdown` field if users would like to link to an external agreement. This is not the case for the current user requesting such an additional checkbox, so this can also be implemented as a follow-up if wanted.
