### PR TITLE
Fix stale settings cache during job execution

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -8,3 +8,17 @@ Delayed::Worker.queue_attributes = {
 
 Delayed::Worker.max_attempts = 1
 Delayed::Worker.destroy_failed_jobs = false
+
+# We use an in-memory cache store that is *not* shared between
+# processes. In order to ensure we do not use outdated, cached
+# settings values, we need to clear the settings cache every
+# time a job is performed.
+class DelayedJobClearCachePlugin < Delayed::Plugin
+  callbacks do |lifecycle|
+    lifecycle.before(:perform) do
+      Setting.clear_cache
+    end
+  end
+end
+
+Delayed::Worker.plugins << DelayedJobClearCachePlugin

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,7 +8,7 @@ x-dev-defaults: &x-dev-defaults
     RAILS_ENV: "${RAILS_ENV:-development}"
     NODE_ENV: "${NODE_ENV:-development}"
     MAILSERVER_HOST: mailserver
-    MAILSERVER_PORT: 25
+    MAILSERVER_PORT: 1025
     POSTGRES_HOST: db
     WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
   stdin_open: true
@@ -41,5 +41,5 @@ services:
     ports: [ '5432:5432' ]
 
   mailserver:
-    image: maildev/maildev
-    ports: [ '1080:80', '1025:25' ]
+    image: maildev/maildev:2.0.2
+    ports: [ '1080:1080', '1025:1025' ]


### PR DESCRIPTION
This is the simplest and most generic solution I could come up with. It’s not tested, as it’s somewhat difficult to test multi-process cache behavior, but I think this fix is quite isolated, so this might be fine?

In order to test this out locally, make sure you can reproduce the bug in your dev env following the instructions in #1276 first. Then switch to this branch and verify that the fix solves the bug.

Instead of registering a DelayedJob lifecyle callback, we could have used `ActiveJob`’s `before_perform` callback. However, this would require some code duplication in order to solve this problem for any async job (mail delivery and other jobs), as we’d have to implement the callback method in both `ApplicationJob` and a subclass of `ActionMailer::MailDeliveryJob`.

Additionally, this would clear the cache any time a job is performed – even if the job is performed synchronously. (This isn’t relevant right now, but it might be unexpected in case we ever use sync jobs in the future.)

Closes #1276 