### PR TITLE
Add admin dashboard for delayed jobs

### DIFF
--- a/app/controllers/admin/delayed_jobs_controller.rb
+++ b/app/controllers/admin/delayed_jobs_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Admin
+  class DelayedJobsController < Admin::ApplicationController; end
+end

--- a/app/dashboards/delayed_job_dashboard.rb
+++ b/app/dashboards/delayed_job_dashboard.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
+
+class DelayedJobDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    queue: Field::String,
+    handler: Field::Text,
+    attempts: Field::Number,
+    last_error: Field::Text,
+    run_at: Field::DateTime,
+    created_at: Field::DateTime,
+    failed_at: Field::DateTime
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i[
+    queue
+    attempts
+    run_at
+    created_at
+    failed_at
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    queue
+    handler
+    attempts
+    last_error
+    created_at
+    failed_at
+  ].freeze
+
+  FORM_ATTRIBUTES = [].freeze
+end

--- a/app/models/delayed_job.rb
+++ b/app/models/delayed_job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class DelayedJob < Delayed::Job; end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,8 +72,9 @@ Rails.application.routes.draw do
       root to: 'users#index'
 
       resources :users
-      resources :contributors, except: %i[new create]
-      resources :requests, except: %i[new create]
+      resources :contributors, only: %i[index show edit destroy]
+      resources :requests, only: %i[index show destroy]
+      resources :delayed_jobs, only: %i[index show destroy]
     end
   end
 


### PR DESCRIPTION
Currently, we try to execute a job at most once, but we do keep failed jobs in the database. We currently do not make use of this, but I think it would be very helpful to be able to see which jobs failed (and why), and (in the future) even to manually retry a failed job.