### PR TITLE
Extract consent checkboxes into separate component

### DIFF
--- a/app/components/base_field/base_field.css
+++ b/app/components/base_field/base_field.css
@@ -30,6 +30,8 @@
   display: flex;
   width: 100%;
   flex-direction: row-reverse;
+  justify-content: start;
+  align-items: start;
 }
 
 .BaseField--leftAligned > input {

--- a/app/components/onboarding_consent/onboarding_consent.html.erb
+++ b/app/components/onboarding_consent/onboarding_consent.html.erb
@@ -1,0 +1,22 @@
+<%= c 'stack', space: :small do %>
+  <%= c('field',
+    object: contributor,
+    attr: :data_processing_consent,
+    style: :leftAligned,
+    help: data_processing_consent_help.html_safe
+  ) do |field| %>
+    <%= c 'checkbox', **field.input_defaults, required: true %>
+  <% end %>
+
+  <% if display_additional_consent_checkbox? %>
+    <%= c('field',
+      object: contributor,
+      attr: :additional_consent,
+      styles: [:leftAligned],
+      label: Setting.onboarding_additional_consent_heading,
+      help: Setting.onboarding_additional_consent_text
+    ) do |field| %>
+      <%= c 'checkbox', field.input_defaults %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/onboarding_consent/onboarding_consent.rb
+++ b/app/components/onboarding_consent/onboarding_consent.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module OnboardingConsent
+  class OnboardingConsent < ApplicationComponent
+    def initialize(contributor:, **)
+      super
+
+      @contributor = contributor
+    end
+
+    private
+
+    attr_reader :contributor
+
+    def data_processing_consent_help
+      I18n.t('contributor.form.data_processing_consent.help', link: Setting.onboarding_data_protection_link)
+    end
+
+    def display_additional_consent_checkbox?
+      Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined?
+    end
+  end
+end

--- a/app/components/onboarding_consent/onboarding_consent.rb
+++ b/app/components/onboarding_consent/onboarding_consent.rb
@@ -17,7 +17,7 @@ module OnboardingConsent
     end
 
     def display_additional_consent_checkbox?
-      Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined?
+      Setting.onboarding_ask_for_additional_consent? && Setting.onboarding_additional_consent_heading.strip.present?
     end
   end
 end

--- a/app/components/onboarding_email_form/onboarding_email_form.html.erb
+++ b/app/components/onboarding_email_form/onboarding_email_form.html.erb
@@ -22,26 +22,7 @@
         <%= c 'input', field.input_defaults.merge(placeholder: '', required: true, type: :email) %>
       <% end %>
 
-      <%= c('field',
-        object: contributor,
-        attr: :data_processing_consent,
-        style: :leftAligned,
-        help: I18n.t('contributor.form.data_processing_consent.help', link: data_protection_link).html_safe
-      ) do |field| %>
-        <%= c 'checkbox', **field.input_defaults, required: true %>
-      <% end %>
-
-      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
-        <%= c('field',
-          object: contributor,
-          attr: :additional_consent,
-          styles: [:horizontal, :leftAligned],
-          label: Setting.onboarding_additional_consent_heading,
-          help: Setting.onboarding_additional_consent_text
-        ) do |field| %>
-          <%= c 'checkbox', field.input_defaults %>
-        <% end %>
-      <% end %>
+      <%= c 'onboarding_consent', contributor: contributor %>
 
       <%= c 'button',
         type: 'submit',

--- a/app/components/onboarding_email_form/onboarding_email_form.rb
+++ b/app/components/onboarding_email_form/onboarding_email_form.rb
@@ -11,9 +11,5 @@ module OnboardingEmailForm
     private
 
     attr_reader :contributor
-
-    def data_protection_link
-      Setting.onboarding_data_protection_link
-    end
   end
 end

--- a/app/components/onboarding_signal_form/onboarding_signal_form.html.erb
+++ b/app/components/onboarding_signal_form/onboarding_signal_form.html.erb
@@ -22,26 +22,7 @@
         <%= c 'input', field.input_defaults.merge(placeholder: '', required: true, type: :tel) %>
       <% end %>
 
-      <%= c('field',
-        object: contributor,
-        attr: :data_processing_consent,
-        styles: [:horizontal, :leftAligned],
-        help: I18n.t('contributor.form.data_processing_consent.help', link: data_protection_link).html_safe
-      ) do |field| %>
-        <%= c 'checkbox', **field.input_defaults, required: true %>
-      <% end %>
-
-      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
-        <%= c('field',
-          object: contributor,
-          attr: :additional_consent,
-          styles: [:horizontal, :leftAligned],
-          label: Setting.onboarding_additional_consent_heading,
-          help: Setting.onboarding_additional_consent_text
-        ) do |field| %>
-          <%= c 'checkbox', field.input_defaults %>
-        <% end %>
-      <% end %>
+      <%= c 'onboarding_consent', contributor: contributor %>
 
       <%= c 'button',
         type: 'submit',

--- a/app/components/onboarding_signal_form/onboarding_signal_form.rb
+++ b/app/components/onboarding_signal_form/onboarding_signal_form.rb
@@ -11,9 +11,5 @@ module OnboardingSignalForm
     private
 
     attr_reader :contributor
-
-    def data_protection_link
-      Setting.onboarding_data_protection_link
-    end
   end
 end

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.html.erb
@@ -24,26 +24,7 @@
         value: contributor.telegram_onboarding_token
       %>
 
-      <%= c('field',
-        object: contributor,
-        attr: :data_processing_consent,
-        style: :leftAligned,
-        help: I18n.t('contributor.form.data_processing_consent.help', link: data_protection_link).html_safe
-      ) do |field| %>
-        <%= c 'checkbox', **field.input_defaults, required: true %>
-      <% end %>
-
-      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
-        <%= c('field',
-          object: contributor,
-          attr: :additional_consent,
-          styles: [:horizontal, :leftAligned],
-          label: Setting.onboarding_additional_consent_heading,
-          help: Setting.onboarding_additional_consent_text
-        ) do |field| %>
-          <%= c 'checkbox', field.input_defaults %>
-        <% end %>
-      <% end %>
+      <%= c 'onboarding_consent', contributor: contributor %>
 
       <%= c 'button',
         type: 'submit',

--- a/app/components/onboarding_telegram_form/onboarding_telegram_form.rb
+++ b/app/components/onboarding_telegram_form/onboarding_telegram_form.rb
@@ -11,9 +11,5 @@ module OnboardingTelegramForm
     private
 
     attr_reader :contributor
-
-    def data_protection_link
-      Setting.onboarding_data_protection_link
-    end
   end
 end

--- a/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.html.erb
@@ -22,26 +22,7 @@
         <%= c 'threema_id_input', field.input_defaults.merge(required: true) %>
       <% end %>
 
-      <%= c('field',
-        object: @contributor,
-        attr: :data_processing_consent,
-        help: I18n.t('contributor.form.data_processing_consent.help', link: data_protection_link).html_safe,
-        style: :leftAligned
-      ) do |field| %>
-        <%= c 'checkbox', **field.input_defaults, required: true %>
-      <% end %>
-
-      <% if Setting.onboarding_ask_for_additional_consent && Setting.onboarding_additional_consent_defined? %>
-        <%= c('field',
-          object: contributor,
-          attr: :additional_consent,
-          styles: [:horizontal, :leftAligned],
-          label: Setting.onboarding_additional_consent_heading,
-          help: Setting.onboarding_additional_consent_text
-        ) do |field| %>
-          <%= c 'checkbox', field.input_defaults %>
-        <% end %>
-      <% end %>
+      <%= c 'onboarding_consent', contributor: contributor %>
 
       <%= c 'button',
         type: 'submit',

--- a/app/components/onboarding_threema_form/onboarding_threema_form.rb
+++ b/app/components/onboarding_threema_form/onboarding_threema_form.rb
@@ -11,9 +11,5 @@ module OnboardingThreemaForm
     private
 
     attr_reader :contributor
-
-    def data_protection_link
-      Setting.onboarding_data_protection_link
-    end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -4,12 +4,6 @@
 class Setting < RailsSettings::Base
   cache_prefix { 'v1' }
 
-  class << self
-    def onboarding_additional_consent_defined?
-      onboarding_additional_consent_heading.strip.present?
-    end
-  end
-
   field :project_name, default: ENV['HUNDRED_EYES_PROJECT_NAME'] || '100eyes'
   field :application_host, readonly: true, default: ENV['APPLICATION_HOSTNAME'] || 'localhost:3000'
 

--- a/spec/adapters/postmark_adapter/outbound_spec.rb
+++ b/spec/adapters/postmark_adapter/outbound_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe PostmarkAdapter::Outbound, type: :mailer do
 
     describe '#welcome_email' do
       before do
-        Setting.onboarding_success_heading = 'Welcome new contributor!'
-        Setting.onboarding_success_text = 'You onboarded successfully.'
+        allow(Setting).to receive(:onboarding_success_heading).and_return('Welcome new contributor!')
+        allow(Setting).to receive(:onboarding_success_text).and_return('You onboarded successfully.')
       end
       let(:contributor) { create(:contributor, email: 'contributor@example.org') }
       let(:welcome_email) do

--- a/spec/components/about_spec.rb
+++ b/spec/components/about_spec.rb
@@ -17,12 +17,19 @@ RSpec.describe About::About, type: :component do
   it { should have_text('redaktion@example.org') }
   it { should have_text('RedaktionBot') }
   it { should have_text('*ABCDEFG') }
-  it { should have_text('Signal ist für diese Instanz nicht aktiviert.') }
 
-  context 'with Signal set up' do
-    before(:each) { allow(Setting).to receive(:signal_server_phone_number).and_return('+4915712345678') }
+  describe 'Signal server phone number' do
+    before(:each) { allow(Setting).to receive(:signal_server_phone_number).and_return(signal_server_phone_number) }
 
-    it { should have_text('0157 1234 5678') }
+    context 'without Signal set up' do
+      let(:signal_server_phone_number) { nil }
+      it { should have_text('Signal ist für diese Instanz nicht aktiviert.') }
+    end
+
+    context 'with Signal set up' do
+      let(:signal_server_phone_number) { '+4915712345678' }
+      it { should have_text('0157 1234 5678') }
+    end
   end
 
   context 'with git commit info set' do

--- a/spec/components/onboarding_consent_spec.rb
+++ b/spec/components/onboarding_consent_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OnboardingConsent::OnboardingConsent, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:contributor) { build(:contributor) }
+  let(:params) { { contributor: contributor } }
+
+  describe 'data processing consent checkbox' do
+    it {
+      should have_field('Einwilligung zur Datenverarbeitung', type: :checkbox, id: 'contributor[data_processing_consent]', checked: false)
+    }
+    it { should have_link(href: Setting.onboarding_data_protection_link) }
+  end
+
+  describe 'additional consent checkbox' do
+    before do
+      allow(Setting).to receive(:onboarding_ask_for_additional_consent).and_return(true)
+      allow(Setting).to receive(:onboarding_additional_consent_heading).and_return('Great expectations.')
+    end
+
+    context 'if additional consent checkbox is enabled' do
+      it { should have_text(Setting.onboarding_additional_consent_heading) }
+      it { should have_field('Great expectations.', type: :checkbox, id: 'contributor[additional_consent]', checked: false) }
+    end
+
+    context 'if additional consent checkbox is disabled' do
+      before { allow(Setting).to receive(:onboarding_ask_for_additional_consent).and_return(false) }
+      it { should_not have_field(:checkbox, id: 'contributor[additional_consent]') }
+    end
+
+    context 'if consent heading is empty' do
+      before { allow(Setting).to receive(:onboarding_additional_consent_heading).and_return('  ') }
+      it { should_not have_field(:checkbox, id: 'contributor[additional_consent]') }
+    end
+  end
+end

--- a/spec/components/onboarding_email_form_spec.rb
+++ b/spec/components/onboarding_email_form_spec.rb
@@ -6,33 +6,7 @@ RSpec.describe OnboardingEmailForm::OnboardingEmailForm, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) { build(:contributor) }
-  let(:params) { { contributor: contributor, jwt: 'JWT' } }
+  let(:params) { { contributor: contributor } }
 
   it { should have_css('.OnboardingEmailForm') }
-  it { should have_link(href: Setting.onboarding_data_protection_link) }
-
-  describe 'additional consent check box' do
-    before do
-      Setting.onboarding_ask_for_additional_consent = true
-      Setting.onboarding_additional_consent_heading = 'Great expectations.'
-    end
-    context 'given a request for additional consent' do
-      it { should have_text(Setting.onboarding_additional_consent_heading) }
-      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no request for additional consent' do
-      before do
-        Setting.onboarding_ask_for_additional_consent = false
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no specified additional consent heading' do
-      before do
-        Setting.onboarding_additional_consent_heading = '  '
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-  end
 end

--- a/spec/components/onboarding_signal_form_spec.rb
+++ b/spec/components/onboarding_signal_form_spec.rb
@@ -6,33 +6,7 @@ RSpec.describe OnboardingSignalForm::OnboardingSignalForm, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) { build(:contributor) }
-  let(:params) { { contributor: contributor, jwt: 'JWT' } }
+  let(:params) { { contributor: contributor } }
 
   it { should have_css('.OnboardingSignalForm') }
-  it { should have_link(href: Setting.onboarding_data_protection_link) }
-
-  describe 'additional consent check box' do
-    before do
-      Setting.onboarding_ask_for_additional_consent = true
-      Setting.onboarding_additional_consent_heading = 'Great expectations.'
-    end
-    context 'given a request for additional consent' do
-      it { should have_text(Setting.onboarding_additional_consent_heading) }
-      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no request for additional consent' do
-      before do
-        Setting.onboarding_ask_for_additional_consent = false
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no specified additional consent heading' do
-      before do
-        Setting.onboarding_additional_consent_heading = '  '
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-  end
 end

--- a/spec/components/onboarding_telegram_form_spec.rb
+++ b/spec/components/onboarding_telegram_form_spec.rb
@@ -6,33 +6,7 @@ RSpec.describe OnboardingTelegramForm::OnboardingTelegramForm, type: :component 
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) { build(:contributor) }
-  let(:params) { { contributor: contributor, jwt: 'JWT' } }
+  let(:params) { { contributor: contributor } }
 
   it { should have_css('.OnboardingTelegramForm') }
-  it { should have_link(href: Setting.onboarding_data_protection_link) }
-
-  describe 'additional consent check box' do
-    before do
-      Setting.onboarding_ask_for_additional_consent = true
-      Setting.onboarding_additional_consent_heading = 'Great expectations.'
-    end
-    context 'given a request for additional consent' do
-      it { should have_text(Setting.onboarding_additional_consent_heading) }
-      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no request for additional consent' do
-      before do
-        Setting.onboarding_ask_for_additional_consent = false
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no specified additional consent heading' do
-      before do
-        Setting.onboarding_additional_consent_heading = '  '
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-  end
 end

--- a/spec/components/onboarding_threema_form_spec.rb
+++ b/spec/components/onboarding_threema_form_spec.rb
@@ -6,33 +6,7 @@ RSpec.describe OnboardingThreemaForm::OnboardingThreemaForm, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) { build(:contributor) }
-  let(:params) { { contributor: contributor, jwt: 'JWT' } }
+  let(:params) { { contributor: contributor } }
 
   it { should have_css('.OnboardingThreemaForm') }
-  it { should have_link(href: Setting.onboarding_data_protection_link) }
-
-  describe 'additional consent check box' do
-    before do
-      Setting.onboarding_ask_for_additional_consent = true
-      Setting.onboarding_additional_consent_heading = 'Great expectations.'
-    end
-    context 'given a request for additional consent' do
-      it { should have_text(Setting.onboarding_additional_consent_heading) }
-      it { should have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no request for additional consent' do
-      before do
-        Setting.onboarding_ask_for_additional_consent = false
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-
-    context 'given no specified additional consent heading' do
-      before do
-        Setting.onboarding_additional_consent_heading = '  '
-      end
-      it { should_not have_css('input[type="checkbox"][name="contributor[additional_consent]"]') }
-    end
-  end
 end

--- a/spec/jobs/signal_adapter/receive_polling_job_spec.rb
+++ b/spec/jobs/signal_adapter/receive_polling_job_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
         let!(:contributor) { create(:contributor, signal_phone_number: '+4915112345789') }
 
         before do
-          Setting.onboarding_success_heading = 'Welcome!'
-          Setting.onboarding_success_text = ''
+          allow(Setting).to receive(:onboarding_success_heading).and_return('Welcome!')
+          allow(Setting).to receive(:onboarding_success_text).and_return('')
         end
 
         it { should_not(change { Message.count }) }

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -639,8 +639,8 @@ RSpec.describe Contributor, type: :model do
   describe '.send_welcome_message!', telegram_bot: :rails do
     let(:contributor) { create(:contributor, telegram_id: nil, email: nil, threema_id: nil) }
     before do
-      Setting.onboarding_success_heading = 'Welcome new contributor!'
-      Setting.onboarding_success_text = 'You onboarded successfully.'
+      allow(Setting).to receive(:onboarding_success_heading).and_return('Welcome new contributor!')
+      allow(Setting).to receive(:onboarding_success_text).and_return('You onboarded successfully.')
     end
     subject { -> { contributor.send_welcome_message! } }
     let(:expected_job_args) { { recipient: contributor, text: "Welcome new contributor!\nYou onboarded successfully." } }

--- a/spec/requests/telegram/webhook_spec.rb
+++ b/spec/requests/telegram/webhook_spec.rb
@@ -5,10 +5,10 @@ require 'telegram/bot/rspec/integration/rails'
 
 RSpec.describe Telegram::WebhookController, telegram_bot: :rails do
   before do
-    Setting.telegram_contributor_not_found_message = 'Who are you?'
-    Setting.telegram_unknown_content_message = "Cannot handle this, I'm sorry :("
-    Setting.onboarding_success_heading = 'Welcome new contributor!'
-    Setting.onboarding_success_text = ''
+    allow(Setting).to receive(:telegram_contributor_not_found_message).and_return('Who are you?')
+    allow(Setting).to receive(:telegram_unknown_content_message).and_return("Cannot handle this, I'm sorry :(")
+    allow(Setting).to receive(:onboarding_success_heading).and_return('Welcome new contributor!')
+    allow(Setting).to receive(:onboarding_success_text).and_return('')
   end
 
   describe '#start!' do


### PR DESCRIPTION
Currently, these two checkboxes (as well as the specs) are duplicated four times.