### PR TITLE
Handle exception in signal receive job

### DIFF
--- a/app/jobs/signal_adapter/receive_polling_job.rb
+++ b/app/jobs/signal_adapter/receive_polling_job.rb
@@ -31,9 +31,9 @@ module SignalAdapter
       end
 
       signal_messages.each do |raw_message|
-        adapter.consume(raw_message) do |m|
-          m.contributor.reply(adapter)
-        end
+        adapter.consume(raw_message) { |m| m.contributor.reply(adapter) }
+      rescue StandardError => e
+        Sentry.capture_exception(e)
       end
 
       ping_monitoring_service && return

--- a/spec/jobs/signal_adapter/receive_polling_job_spec.rb
+++ b/spec/jobs/signal_adapter/receive_polling_job_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
         end
 
         it 'sends error to Sentry' do
-          subject.call
+          expect { subject.call }.not_to raise_error
           expect(Sentry).to have_received(:capture_exception)
           expect(job).to have_received(:ping_monitoring_service)
         end

--- a/spec/jobs/signal_adapter/receive_polling_job_spec.rb
+++ b/spec/jobs/signal_adapter/receive_polling_job_spec.rb
@@ -49,10 +49,24 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
         end
 
         allow(job).to receive(:ping_monitoring_service).and_return(nil)
-        allow(Sentry).to receive(:capture_exception).with(an_instance_of(SignalAdapter::UnknownContributorError))
+      end
+
+      context 'if consuming the message fails' do
+        before do
+          allow(Sentry).to receive(:capture_exception).with(an_instance_of(StandardError))
+          allow_any_instance_of(SignalAdapter::Inbound).to receive(:consume).and_raise(StandardError)
+        end
+
+        it 'sends error to Sentry' do
+          subject.call
+          expect(Sentry).to have_received(:capture_exception)
+          expect(job).to have_received(:ping_monitoring_service)
+        end
       end
 
       describe 'given a message from an unknown contributor' do
+        before { allow(Sentry).to receive(:capture_exception).with(an_instance_of(SignalAdapter::UnknownContributorError)) }
+
         it { should_not(change { Message.count }) }
 
         it 'sends an error to Sentry so that our admins get notified' do
@@ -102,6 +116,7 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
 
       describe 'given multiple messages from known and unknown contributors', vcr: { cassette_name: :receive_multiple_signal_messages } do
         before do
+          allow(Sentry).to receive(:capture_exception).with(an_instance_of(SignalAdapter::UnknownContributorError))
           create(:contributor, signal_phone_number: '+4915112345789', signal_onboarding_completed_at: Time.zone.now)
         end
 


### PR DESCRIPTION
We’ve run into situations were `SignalAdapter::Inbound` (e.g. #1275) raises an error (and we can’t be sure this might not happen again in the future). It’s rather unlikely, but in case we did receive multiple Signal messages and the adapter raised an error for one of them, the other messages would be discarded.

This PR rescues any errors that are raised by `SignalAdapter::Inbound`, but keeps reporting them to Sentry so we’re still alerted about them.