### PR TITLE
Remove `spring-watcher-listen` and update `spring` to v4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-commands-rspec'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,9 +347,6 @@ GEM
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -425,7 +422,6 @@ DEPENDENCIES
   sentry-ruby
   spring
   spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
   telegram-bot
   threema!
   timecop
@@ -439,4 +435,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.31
+   2.3.11

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
+load File.expand_path("spring", __dir__)
 require 'bundler/setup'
 load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
+
+# This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
 if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
-  gem "bundler"
   require "bundler"
 
-  # Load Spring without loading other gems in the Gemfile, for speed.
-  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem "spring", spring.version
     require "spring/binstub"
-  rescue Gem::LoadError
-    # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION
`spring-watcher-listen` uses file system events (instead of polling) to reload files in the development environment, which should be a little more CPU efficient. However, `spring-watcher-listen` requires spring –– the most recent version of `spring` being v4.

spring v2 has been super slow for my setup (Docker for Mac), with initial boot times of up to 5 *minutes* (so in practice, I’ve rarely used it at all). Updating to v4 has solved this (at least for me).

Is there a noticeable performance impact when not using `spring-watcher-listen` with your setups? If not, can we remove this gem so we can update to spring v3.