### PR TITLE
Add support for Signal typing messages

### DIFF
--- a/app/adapters/signal_adapter/inbound.rb
+++ b/app/adapters/signal_adapter/inbound.rb
@@ -63,9 +63,9 @@ module SignalAdapter
     end
 
     def initialize_message(signal_message)
-      is_receipt = signal_message.dig(:envelope, :receiptMessage)
+      is_data_message = signal_message.dig(:envelope, :dataMessage)
       is_remove_emoji = signal_message.dig(:envelope, :dataMessage, :reaction, :isRemove)
-      return nil if is_receipt || is_remove_emoji
+      return nil if !is_data_message || is_remove_emoji
 
       data_message = signal_message.dig(:envelope, :dataMessage)
       reaction = data_message[:reaction]

--- a/spec/adapters/signal_adapter/inbound_spec.rb
+++ b/spec/adapters/signal_adapter/inbound_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SignalAdapter::Inbound do
     }
   end
 
-  let(:receipt_message) do
+  let(:signal_receipt_message) do
     {
       envelope: {
         source: '+4912345789',
@@ -161,6 +161,20 @@ RSpec.describe SignalAdapter::Inbound do
     }
   end
 
+  let(:signal_typing_message) do
+    {
+      envelope: {
+        source: '+4912345789',
+        sourceDevice: 1,
+        timestamp: 1648534000000,
+        typingMessage: {
+          action: "STARTED",
+          timestamp: 1648534000000
+        }
+      }
+    }
+  end
+
   before do
     allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open)
@@ -205,7 +219,13 @@ RSpec.describe SignalAdapter::Inbound do
       end
 
       context 'given a receipt message' do
-        let(:signal_message) { receipt_message }
+        let(:signal_message) { signal_receipt_message }
+
+        it { should be(nil) }
+      end
+
+      context 'given a typing indicator message' do
+        let(:signal_message) { signal_typing_message }
 
         it { should be(nil) }
       end

--- a/spec/adapters/signal_adapter/inbound_spec.rb
+++ b/spec/adapters/signal_adapter/inbound_spec.rb
@@ -166,10 +166,10 @@ RSpec.describe SignalAdapter::Inbound do
       envelope: {
         source: '+4912345789',
         sourceDevice: 1,
-        timestamp: 1648534000000,
+        timestamp: 1_648_534_000_000,
         typingMessage: {
-          action: "STARTED",
-          timestamp: 1648534000000
+          action: 'STARTED',
+          timestamp: 1_648_534_000_000
         }
       }
     }


### PR DESCRIPTION
Closes #1275.

Previously, we handled supported messages by explicitly checking if a message was of an unsupported type. As all messages that we currently want to handle are of the `dataMessage` type, I changed the check to excluding / not handling anything that is not a `dataMessage`. Hopefully, that will help us avoid future issues with other message types which we don't support.

I was not able to reproduce this error on a live System (Staging). However, the structure of the message that could not be handled (which is included in the Sentry ticket) allowed for reproducing the issue locally. As I think the cause of the bug is quite obvious, I would be ok with working with the fix without trying to reproduce it extensively on Staging.

I have typing indicators activated in my Signal account but somehow even with two continuous minutes of typing, no typing events were sent to Staging. For the moment I don't think the time-effect tradeoff warrants putting more time into trying to reproduce the issue on Staging.