### PR TITLE
Fix watch mode for npm `build:**` scripts

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -29,7 +29,7 @@ services:
       - 3035:3035
 
   assets:
-    command: npm run build
+    command: npm run dev
     <<: *x-dev-defaults
 
   job-worker:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "build:css": "postcss ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.css",
     "build:js": "bin/esbuild",
-    "build": "run-p -l 'build:** --watch'",
+    "build": "run-p -l build:**",
+    "dev": "run-p -l 'build:** -- --watch'",
     "prettier": "prettier --check 'app/**/!(build)/*.{js,css}'",
     "prettier:fix": "prettier --write 'app/**/!(build)/*.{js,css}'"
   },


### PR DESCRIPTION
I think this broke when replacing yarn with npm. Unlike yarn, npm requires additional command line options for npm scripts to be separated with a double dash (`--`):

```
yarn build:css --watch
npm run build:css -- --watch
```

https://docs.npmjs.com/cli/v8/commands/npm-run-script

I have also changed the `build` script to run in default mode and added a new `dev` script that runs esbuild and postcss in watch mode as I think most people wouldn’t expect a default `build` script to run in watch mode.