### PR TITLE
Add csv export functionality to admin contributor dashboard.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,4 @@ gem 'sentry-ruby'
 
 # Admin
 gem 'administrate'
+gem 'administrate_exportable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,11 @@ GEM
       momentjs-rails (~> 2.8)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
+    administrate_exportable (0.5.0)
+      actionview (>= 5.2.2.1)
+      administrate (>= 0.13.0)
+      rails (>= 4.2)
+      railties (>= 5.2.2.1)
     argon2 (2.0.3)
       ffi (~> 1.14)
       ffi-compiler (~> 1.0)
@@ -390,6 +395,7 @@ DEPENDENCIES
   activestorage-validator (~> 0.2.0)
   acts-as-taggable-on
   administrate
+  administrate_exportable
   bootsnap (>= 1.4.2)
   browser
   byebug

--- a/app/controllers/admin/contributors_controller.rb
+++ b/app/controllers/admin/contributors_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class ContributorsController < Admin::ApplicationController; end
+  class ContributorsController < Admin::ApplicationController
+    include AdministrateExportable::Exporter
+  end
 end

--- a/app/dashboards/contributor_dashboard.rb
+++ b/app/dashboards/contributor_dashboard.rb
@@ -12,7 +12,9 @@ class ContributorDashboard < Administrate::BaseDashboard
     note: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    deactivated_at: Field::DateTime
+    deactivated_at: Field::DateTime,
+    data_processing_consented_at: Field::DateTime,
+    additional_consent_given_at: Field::DateTime
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
@@ -21,6 +23,8 @@ class ContributorDashboard < Administrate::BaseDashboard
     last_name
     channels
     active
+    data_processing_consented_at
+    additional_consent_given_at
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
@@ -29,6 +33,8 @@ class ContributorDashboard < Administrate::BaseDashboard
     last_name
     active
     channels
+    data_processing_consented_at
+    additional_consent_given_at
     note
     created_at
     updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,9 @@ Rails.application.routes.draw do
       root to: 'users#index'
 
       resources :users
-      resources :contributors, only: %i[index show edit destroy]
+      resources :contributors, only: %i[index show edit destroy] do
+        get :export, on: :collection
+      end
       resources :requests, only: %i[index show destroy]
       resources :messages, only: %i[index show destroy]
       resources :delayed_jobs, only: %i[index show destroy]


### PR DESCRIPTION
This PR adds CSV download functionality on the admin dashboard for contributors:

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/34538290/166471094-d44a4737-2e5c-4da2-a21a-2f7ce3d910d5.png">

It additionally adds `Data Processing Consented At` and `Additional Consent Given At` as displayed fields in the admin dashboard and therefore also in the downloaded CSV, as this information will be often needed in an export. The CSV file then contains all features visible in a single Contributor view of the dashboard (e.g. also `note`, `Created At` and `Updated At`).

This feature introduces a new dependency on the ['administrate-exportable'](https://github.com/SourceLabsLLC/administrate_exportable) gem. Using the gem made adding download functionality very easy. However, the gem is not widely used but appears at least somewhat maintained (after all it really has only one function and doesn't need to be updated often). Nevertheless, I had a short look through the code and did not find any apparent issues.

Adding the download functionality in the admin dashboard was the quickest way to approach #190. I am not sure if we can consider #190 closed, however, as this only allows admins to download the contributor data and not all users as described in #190. What is your opinion @FrauCsu / @drjakob ?