### PR TITLE
Add contact information to contributor dashboard & CSV export.

### DIFF
--- a/app/dashboards/contributor_dashboard.rb
+++ b/app/dashboards/contributor_dashboard.rb
@@ -9,6 +9,10 @@ class ContributorDashboard < Administrate::BaseDashboard
     last_name: Field::String,
     active: Field::Boolean,
     channels: Field::String.with_options(searchable: false),
+    email: Field::String,
+    username: Field::String,
+    signal_phone_number: Field::String,
+    threema_id: Field::String,
     note: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -33,6 +37,10 @@ class ContributorDashboard < Administrate::BaseDashboard
     last_name
     active
     channels
+    email
+    username
+    signal_phone_number
+    threema_id
     data_processing_consented_at
     additional_consent_given_at
     note

--- a/app/dashboards/contributor_dashboard.rb
+++ b/app/dashboards/contributor_dashboard.rb
@@ -11,8 +11,13 @@ class ContributorDashboard < Administrate::BaseDashboard
     channels: Field::String.with_options(searchable: false),
     email: Field::String,
     username: Field::String,
+    telegram_id: Field::Number,
     signal_phone_number: Field::String,
     threema_id: Field::String,
+    phone: Field::String,
+    additional_email: Field::String,
+    zip_code: Field::String,
+    city: Field::String,
     note: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -39,14 +44,19 @@ class ContributorDashboard < Administrate::BaseDashboard
     channels
     email
     username
+    telegram_id
     signal_phone_number
     threema_id
-    data_processing_consented_at
-    additional_consent_given_at
+    phone
+    additional_email
+    zip_code
+    city
     note
     created_at
     updated_at
     deactivated_at
+    data_processing_consented_at
+    additional_consent_given_at
   ].freeze
 
   FORM_ATTRIBUTES = %i[

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -689,6 +689,9 @@ de:
       create: "%{model} erstellen"
       submit: "%{model} speichern"
       update: "%{model} aktualisieren"
+    label:
+      contributor:
+        username: Telegram Username
   number:
     currency:
       format:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -692,6 +692,8 @@ de:
     label:
       contributor:
         username: Telegram Username
+        threema_id: Threema Id
+        telegram_id: Telegram Id
   number:
     currency:
       format:


### PR DESCRIPTION
This PR adds contact information to the contributor dashboard and CSV export.

There are two beauty issues with the name of columns in the CSV export file:

<img width="869" alt="image" src="https://user-images.githubusercontent.com/34538290/167146493-0a25a401-d3c1-422e-b7e9-dfdb0f0890b0.png">

The field holding the telegram username is only called `username` in our database instead of `telegram_username`. For the contributor view in the contributor dashboard, I was able to change the label to `Telegram Username` by specifying a label in the i18n file. The gem we use for the export (`administrate_exportable`) however doesn't use the label, leading to a somewhat unspecific `Username` column. 
If there is nothing speaking against a migration, I would propose migrating `username` to `telegram_username` as a follow-up. This would also improve clarity in our own schema and solve this issue.

That the threema ID column is not titelized is intentional of the implementation from `administrate_exportable` that treats `*_id` attributes special (not titelizing them). As I don't see a quick fix for that and don't think it is very relevant, I would propose living with it for the moment.
