### PR TITLE
Ensure that toggle button never overlays message text

### DIFF
--- a/app/components/chat_message/chat_message.css
+++ b/app/components/chat_message/chat_message.css
@@ -48,6 +48,13 @@
   display: block;
 }
 
+/* Reserve space in last line to prevent that the toggle button overlays text */
+.ChatMessage--expanded .ChatMessage-text p:last-child::after {
+  content: '';
+  display: inline-block;
+  width: 5em;
+}
+
 .ChatMessage-meta {
   color: var(--color-text-light);
   font-size: var(--font-size-s);


### PR DESCRIPTION
This adds a spacer pseudo element to the last line of the message text. The spacer element has the same approx. width as the toggle button.

This way, the toggle button is displayed on the next line if it would otherwise overlay the message text. However, if there’s enough space on the last line, there’s no additional white space inserted.

I've highlighted the pseudo element in red in the following two screenshots:

| Case 1 | Case 2 |
|-|-|
| ![image](https://user-images.githubusercontent.com/1512805/168801758-f3d6433d-0803-47d8-9730-33481763ffce.png) | ![image](https://user-images.githubusercontent.com/1512805/168801862-c861d6c2-0e18-4320-97ad-c67f9ab3c550.png) |
