### PR TITLE
Fix sending emails with commas in their sender name.

### DIFF
--- a/app/adapters/postmark_adapter/outbound.rb
+++ b/app/adapters/postmark_adapter/outbound.rb
@@ -62,7 +62,7 @@ module PostmarkAdapter
     end
 
     def default_from
-      "#{Setting.project_name} <#{Setting.email_from_address}>"
+      "\"#{Setting.project_name}\" <#{Setting.email_from_address}>"
     end
   end
 end

--- a/spec/adapters/postmark_adapter/outbound_spec.rb
+++ b/spec/adapters/postmark_adapter/outbound_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe PostmarkAdapter::Outbound, type: :mailer do
 
         subject { message_email[:from].formatted }
         it { should eq(['TestingProject <100eyes-test-account@example.org>']) }
+
+        context 'with a comma / list separator in the project name' do
+          before do
+            allow(Setting).to receive(:project_name).and_return('TestingProject, with a comma!')
+          end
+
+          it { should eq(['"TestingProject, with a comma!" <100eyes-test-account@example.org>']) }
+        end
       end
 
       describe 'plaintext body' do


### PR DESCRIPTION
To comply with RFC 5322 (https://www.rfc-editor.org/rfc/rfc5322#section-3.6.2) where commas in the from: field specify a list of multiple senders, we need to escape commas in the sender name. This is necessary if a project specifies its project name and therefore the sender name, e.g. as 'Coffee, and you?'.

Closes #1341.