### PR TITLE
Update signal-cli-rest-api version.

### DIFF
--- a/app/adapters/signal_adapter/inbound.rb
+++ b/app/adapters/signal_adapter/inbound.rb
@@ -89,7 +89,7 @@ module SignalAdapter
 
     def initialize_files(signal_message)
       attachments = signal_message.dig(:envelope, :dataMessage, :attachments)
-      return [] unless attachments.any?
+      return [] unless attachments&.any?
 
       if attachments.any? { |attachment| SUPPORTED_ATTACHMENT_TYPES.exclude?(attachment[:contentType]) }
         @message.unknown_content = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   signal:
-    image: bbernhard/signal-cli-rest-api:0.42
+    image: bbernhard/signal-cli-rest-api:0.59
     environment:
       - USE_NATIVE=0
         #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)

--- a/spec/adapters/signal_adapter/inbound_spec.rb
+++ b/spec/adapters/signal_adapter/inbound_spec.rb
@@ -14,10 +14,7 @@ RSpec.describe SignalAdapter::Inbound do
           timestamp: 1_626_708_555_697,
           message: 'Hello 100eyes',
           expiresInSeconds: 0,
-          viewOnce: false,
-          mentions: [],
-          attachments: [],
-          contacts: []
+          viewOnce: false
         }
       }
     }
@@ -52,14 +49,12 @@ RSpec.describe SignalAdapter::Inbound do
           message: 'Hello 100eyes',
           expiresInSeconds: 0,
           viewOnce: false,
-          mentions: [],
           attachments: [{
             contentType: 'audio/aac',
             filename: 'Sprachnachricht.m4a',
             id: 'zuNhdpIHpRU_9Du-B4oG',
             size: 89_549
-          }],
-          contacts: []
+          }]
         }
       }
     }
@@ -76,7 +71,6 @@ RSpec.describe SignalAdapter::Inbound do
           message: 'Hello 100eyes',
           expiresInSeconds: 0,
           viewOnce: false,
-          mentions: [],
           attachments: [{
             contentType: 'image/jpeg',
             filename: 'signal-2021-09.jpeg',
@@ -88,8 +82,7 @@ RSpec.describe SignalAdapter::Inbound do
                           filename: 'signal-2021-09.jpeg',
                           id: 'zuNhdpIHpRU_9Du-B4oG',
                           size: 115_809
-                        }],
-          contacts: []
+                        }]
         }
       }
     }
@@ -105,10 +98,7 @@ RSpec.describe SignalAdapter::Inbound do
           timestamp: 1_626_708_555_697,
           message: nil,
           expiresInSeconds: 3600,
-          viewOnce: false,
-          mentions: [],
-          attachments: [],
-          contacts: []
+          viewOnce: false
         }
       }
     }
@@ -127,10 +117,7 @@ RSpec.describe SignalAdapter::Inbound do
           remoteDelete: {
             timestamp: 1_630_444_176_328
           },
-          viewOnce: false,
-          mentions: [],
-          attachments: [],
-          contacts: []
+          viewOnce: false
         }
       }
     }
@@ -152,10 +139,7 @@ RSpec.describe SignalAdapter::Inbound do
             targetAuthor: '+4912345781',
             targetSentTimestamp: 1_630_442_783_119,
             isRemove: false
-          },
-          mentions: [],
-          attachments: [],
-          contacts: []
+          }
         }
       }
     }

--- a/vcr_cassettes/receive_multiple_signal_messages.yml
+++ b/vcr_cassettes/receive_multiple_signal_messages.yml
@@ -35,10 +35,7 @@ http_interactions:
                 "timestamp": 1630589332148,
                 "message": "Message from Misses X",
                 "expiresInSeconds": 0,
-                "viewOnce": false,
-                "mentions": [],
-                "attachments": [],
-                "contacts": []
+                "viewOnce": false
             }
         }
       },
@@ -51,10 +48,7 @@ http_interactions:
                 "timestamp": 1630589338630,
                 "message": "Message from known contributor",
                 "expiresInSeconds": 0,
-                "viewOnce": false,
-                "mentions": [],
-                "attachments": [],
-                "contacts": []
+                "viewOnce": false
             }
         }
       }]'

--- a/vcr_cassettes/receive_signal_messages.yml
+++ b/vcr_cassettes/receive_signal_messages.yml
@@ -27,6 +27,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"envelope":{"source":"+4915112345789","sourceDevice":2,"timestamp":1626884435591,"dataMessage":{"timestamp":1626884435591,"message":"Hello
-        World!","expiresInSeconds":0,"viewOnce":false,"mentions":[],"attachments":[],"contacts":[]}}}]'
+        World!","expiresInSeconds":0,"viewOnce":false}}}]'
   recorded_at: Wed, 21 Jul 2021 16:20:49 GMT
 recorded_with: VCR 6.0.0

--- a/vcr_cassettes/receive_signal_messages_containing_unsupported_attachment.yml
+++ b/vcr_cassettes/receive_signal_messages_containing_unsupported_attachment.yml
@@ -36,14 +36,12 @@ http_interactions:
                         "message": null,
                         "expiresInSeconds": 0,
                         "viewOnce": false,
-                        "mentions": [],
                         "attachments": [{
                             "contentType": "application/pdf",
                             "filename": "verygoodpdf.pdf",
                             "id": "4672339980807658243",
                             "size": 1806406
-                        }],
-                        "contacts": []
+                        }]
                     }
                 }
             }]'


### PR DESCRIPTION
Since about two weeks ago registering new signal server phone numbers over the `signal-cli-rest-api` failed with a timeout.
These issues appear to have been caused by an outdated version, pushing the version from 0.42 to 0.59 (aka the latest version) resolved them.

However, this update also changed the structure of the signal message objects we receive. Mainly it adds new metainformation, e.g. the `sourceName` and a different `sticker` id format, which are not relevant for us. However, it also doesn't use empty attribute lists e.g. for `attachments: []` but instead doesn't include these attributes at all. This broke our code that depended on always being able to access an `attachments` attribute.
This PR fixes that.

Fixing the `signal-cli-rest-api` version to `0.59` as proposed in this PR would switch all current instances to the `0.59` version at the next deployment. I tested switching on staging, where also a signal phone number was already registered. This worked well. However, if we want to be cautious, we should only use the new version for new instances (as so far, no problems except for registering occured with the old version.) 

Edit: Regarding updating the `signal-cli-rest-api`: While updating to a higher version worked well, downgrading again to a lower version caused issues, which I could only resolve by completely reregistering the number by hand, meaning having to delete the phone number data directories by hand. (The downgrade happened on staging when I merged a security fix yesterday night, which lead to a new deploy on staging, again with the `0.42` `signal-cli-rest-api`).
Having to reregister a phone number on a production instance could potentially break those instances. As far as I experienced it on the `staging` system there were issues with sending messages to signal users who did not accept the number change in their client beforehand. 
Obviously, once we changed the version on `master` an accidental downgrade shouldn't be an issue. But the update does appear to be a bit brittle, what do you think?
