### PR TITLE
Display raw message data in admin dashboard

### DIFF
--- a/app/dashboards/message_dashboard.rb
+++ b/app/dashboards/message_dashboard.rb
@@ -9,7 +9,8 @@ class MessageDashboard < Administrate::BaseDashboard
     recipient: Field::BelongsTo,
     request: Field::BelongsTo,
     created_at: Field::DateTime,
-    text: Field::Text
+    text: Field::Text,
+    raw_data: RawDataField
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[

--- a/app/fields/raw_data_field.rb
+++ b/app/fields/raw_data_field.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'administrate/field/base'
+
+class RawDataField < Administrate::Field::Base; end

--- a/app/views/fields/raw_data_field/_form.html.erb
+++ b/app/views/fields/raw_data_field/_form.html.erb
@@ -1,0 +1,4 @@
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field"></div>

--- a/app/views/fields/raw_data_field/_show.html.erb
+++ b/app/views/fields/raw_data_field/_show.html.erb
@@ -1,0 +1,9 @@
+<ul>
+  <% field.data.each do |file| %>
+    <li>
+      <a href="<%= rails_blob_path(file, disposition: :inline) %>" target="_blank">
+        <%= file.filename %>
+      </a>
+    </li>
+  <% end %>
+</ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,10 @@ module App
     config.i18n.default_locale = :de
     config.time_zone = 'Berlin'
     config.i18n.fallbacks = true
+
+    # Serve JSON files inline, i.e. without forcing a download. This allows
+    # us to preview raw message data, which is often stored as JSON, directly
+    # in the browser.
+    config.active_storage.content_types_allowed_inline << 'application/json'
   end
 end

--- a/spec/features/admin/raw_data_spec.rb
+++ b/spec/features/admin/raw_data_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Raw data', type: :feature do
+  let(:user) { create(:user, admin: true) }
+  let(:message) { create(:message) }
+
+  scenario 'admin debugs raw message data' do
+    visit admin_message_path(id: message.id, as: user)
+    click_on 'text.json'
+
+    expect(page.body).to eq('{"text":"Hello"}')
+    expect(page.response_headers['Content-Type']).to eq('application/json')
+    expect(page.response_headers['Content-Disposition']).to start_with('inline;')
+  end
+end


### PR DESCRIPTION
This displays the raw message data in the admin dashboard in order to help debugging messages that contain unsupported content types etc.

We store the raw message data for all inbound messages as ActiveStorage attachments. administrate doesn’t support attachments out of the box. There are gems that add support, but in this case, all we need is to display a list of links to those attachments, which can be implemented without too much effort using a custom administrate field type.

Closes #462