### PR TITLE
Enable contributors edit from admin dashboard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       root to: 'users#index'
 
       resources :users
-      resources :contributors, only: %i[index show edit destroy] do
+      resources :contributors, only: %i[index show destroy] do
         get :export, on: :collection
       end
       resources :requests, only: %i[index show destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       root to: 'users#index'
 
       resources :users
-      resources :contributors, only: %i[index show destroy] do
+      resources :contributors, only: %i[index show edit update destroy] do
         get :export, on: :collection
       end
       resources :requests, only: %i[index show destroy]

--- a/spec/features/admin/contributors_spec.rb
+++ b/spec/features/admin/contributors_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Contributors', type: :feature do
+  context 'as admin' do
+    let(:user) { create(:user, first_name: 'Max', last_name: 'Mustermann', admin: true, password: '12345678') }
+    let!(:contributor) { create(:contributor, first_name: 'Zora', last_name: 'Zimmermann') }
+
+    scenario 'admin edits contributor' do
+      visit admin_contributors_path(as: user)
+
+      click_on 'Edit'
+      fill_in 'First name', with: 'Zora Z.'
+      click_on 'Update Contributor'
+
+      expect(page).to have_text('Contributor was successfully updated.')
+      expect(page).to have_text('Show Zora Z. Zimmermann')
+    end
+  end
+end


### PR DESCRIPTION
Editing contributors via the admin dashboard isn’t possible, but the edit form for contributors is accessible via an “Edit” button in the admin dashboard. This removes the respective `edit` route. As administrate automatically displays/hides action buttons (like the edit button) depending on wether a respective route is available, this will also hide the “Edit” button in the admin dashboard.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1512805/171472773-2bc7b4a6-f566-4a7b-ab9b-aafa554e05d8.png) | ![image](https://user-images.githubusercontent.com/1512805/171472745-9b5040c7-21c7-48e0-9525-790de6895013.png) |

Closes #1350