### PR TITLE
Display phone number in profiles of contributors with incomplete onboarding

### DIFF
--- a/app/components/contributor_signal_settings/contributor_signal_settings.html.erb
+++ b/app/components/contributor_signal_settings/contributor_signal_settings.html.erb
@@ -18,6 +18,7 @@
             name: contributor.name,
             first_name: contributor.first_name,
             date: l(contributor.created_at.to_date),
+            phone_number: contributor.signal_phone_number.phony_formatted,
           ) %>
         </p>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -200,7 +200,7 @@ de:
           %{name} hat sich mit der Handynummer %{phone_number} angemeldet.
       incomplete:
         text: |
-          %{name} hat sich am %{date} via Signal angemeldet, die Anmeldung aber noch nicht abgeschlossen.
+          %{name} hat sich am %{date} via Signal mit der Handynummer %{phone_number} angemeldet, die Anmeldung aber noch nicht abgeschlossen.
           Sende %{first_name} einen Link mit Hinweisen zum Abschließen der Anmeldung.
         action: Link kopieren
     contributor_header:

--- a/spec/components/contributor_signal_settings_spec.rb
+++ b/spec/components/contributor_signal_settings_spec.rb
@@ -24,10 +24,8 @@ RSpec.describe ContributorSignalSettings::ContributorSignalSettings, type: :comp
   context 'given a contributor with incomplete onboarding' do
     let(:onboarding_completed_at) { nil }
 
-    it {
-      should have_css('p',
-                      text: 'Max Mustermann hat sich am 01.01.2021 via Signal angemeldet, die Anmeldung aber noch nicht abgeschlossen.')
-    }
+    it { should have_css('p', text: 'Max Mustermann hat sich am 01.01.2021 via Signal') }
+    it { should have_css('p', text: 'mit der Handynummer 0151 1234 5678 angemeldet, die Anmeldung aber noch nicht abgeschlossen.') }
     it { should have_css('p', text: 'Sende Max einen Link mit Hinweisen zum Abschließen der Anmeldung.') }
     it { should have_css('button[data-copy-button-copy-value$="http://test.host/onboarding/signal/link"]') }
   end


### PR DESCRIPTION
This displays the phone number used for Signal onboarding in the contributors profile, so editors can contact them to assist with finishing the onboarding process.

![image](https://user-images.githubusercontent.com/1512805/171473548-374fc48a-96e0-4b0a-887b-d9f5eb9e008e.png)

Fixes #1349