### PR TITLE
Upcase Threema IDs

### DIFF
--- a/app/adapters/threema_adapter/inbound.rb
+++ b/app/adapters/threema_adapter/inbound.rb
@@ -12,7 +12,7 @@ module ThreemaAdapter
     def initialize(threema_message)
       decrypted_message = Threema.new.receive(payload: threema_message)
 
-      @sender = Contributor.find_by(threema_id: threema_message[:from])
+      @sender = Contributor.where('UPPER(threema_id) = ?', threema_message[:from]).first
       return unless @sender
 
       @delivery_receipt = delivery_receipt?(decrypted_message)

--- a/app/adapters/threema_adapter/outbound.rb
+++ b/app/adapters/threema_adapter/outbound.rb
@@ -26,7 +26,7 @@ module ThreemaAdapter
     end
 
     def perform(recipient:, text:)
-      self.class.threema_instance.send(type: :text, threema_id: recipient.threema_id, text: text)
+      self.class.threema_instance.send(type: :text, threema_id: recipient.threema_id.upcase, text: text)
     end
   end
 end

--- a/app/components/threema_id_input/threema_id_input.css
+++ b/app/components/threema_id_input/threema_id_input.css
@@ -1,0 +1,3 @@
+.ThreemaIdInput > input {
+  text-transform: uppercase;
+}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -413,7 +413,7 @@ de:
         label: Handynummer
       threema_id:
         label: Threema ID
-        help: 6 Zeichen lang, besteht nur aus Zahlen und Buchstaben
+        help: 6 Zeichen lang, besteht nur aus Zahlen und Großbuchstaben
         placeholder: z.B. A12BC345
       username:
         label: Telegram

--- a/spec/adapters/threema_adapter/inbound_spec.rb
+++ b/spec/adapters/threema_adapter/inbound_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ThreemaAdapter::Inbound do
-  before { create(:contributor, threema_id: 'V5EA564T') }
+  let(:threema_id) { 'V5EA564T' }
+  let!(:contributor) { create(:contributor, threema_id: threema_id) }
 
   let(:threema_message) { described_class.new(message) }
   let(:message) do
@@ -49,6 +50,16 @@ RSpec.describe ThreemaAdapter::Inbound do
     describe 'saving the message' do
       subject { threema_message.message.raw_data }
       it { should be_attached }
+    end
+  end
+
+  describe '#contributor' do
+    subject { threema_message.message.contributor }
+    it { should eq(contributor) }
+
+    context 'if contributor has lowercase Threema ID' do
+      let(:threema_id) { 'v5ea564t' }
+      it { should eq(contributor) }
     end
   end
 

--- a/spec/adapters/threema_adapter/outbound_spec.rb
+++ b/spec/adapters/threema_adapter/outbound_spec.rb
@@ -4,18 +4,17 @@ require 'rails_helper'
 
 RSpec.describe ThreemaAdapter::Outbound do
   let(:adapter) { described_class.new }
-  let(:threema) { instance_double(Threema) }
-  let(:contributor) { create(:contributor, threema_id: 'V5EA564T', email: nil) }
+  let(:threema_id) { 'V5EA564T' }
+  let(:contributor) { create(:contributor, threema_id: threema_id, email: nil) }
   let(:message) { create(:message, recipient: contributor) }
-
-  before do
-    allow(Threema).to receive(:new).and_return(threema)
-  end
 
   describe '::send!' do
     before { message } # we don't count the extra ::send here
+
     subject { -> { described_class.send!(message) } }
+
     it { should enqueue_job(described_class) }
+
     context 'contributor has no threema_id' do
       let(:contributor) { create(:contributor, threema_id: nil, email: nil) }
       it { should_not enqueue_job(described_class) }
@@ -24,7 +23,9 @@ RSpec.describe ThreemaAdapter::Outbound do
 
   describe '::send_welcome_message!' do
     subject { -> { described_class.send_welcome_message!(contributor) } }
+
     it { should enqueue_job(described_class) }
+
     context 'contributor has no threema_id' do
       let(:contributor) { create(:contributor, threema_id: nil, email: nil) }
       it { should_not enqueue_job(described_class) }
@@ -32,21 +33,30 @@ RSpec.describe ThreemaAdapter::Outbound do
   end
 
   describe '#perform' do
-    subject { adapter.perform(text: message.text, recipient: message.recipient) }
+    subject { -> { adapter.perform(text: message.text, recipient: message.recipient) } }
 
     it 'sends the message' do
-      expect(threema).to receive(:send).with({ type: :text, threema_id: contributor.threema_id, text: message.text })
-
-      subject
+      expect_any_instance_of(Threema).to receive(:send).with(type: :text, threema_id: 'V5EA564T', text: message.text)
+      subject.call
     end
 
-    describe '#welcome_message' do
-      subject { described_class.welcome_message }
-      it 'strips whitespace to not break basic formatting' do
-        allow(Setting).to receive(:onboarding_success_heading).and_return(" \n text with leading and trailing whitespace \t \n ")
-        allow(Setting).to receive(:onboarding_success_text).and_return("\nSuccess text.\n")
-        is_expected.to eq("*text with leading and trailing whitespace*\n\nSuccess text.\n")
+    context 'with lowercase Threema ID' do
+      let(:threema_id) { 'v5ea564t' }
+
+      it 'converts ID to uppercase' do
+        expect_any_instance_of(Threema).to receive(:send).with(type: :text, threema_id: 'V5EA564T', text: message.text)
+        subject.call
       end
+    end
+  end
+
+  describe '#welcome_message' do
+    subject { described_class.welcome_message }
+
+    it 'strips whitespace to not break basic formatting' do
+      allow(Setting).to receive(:onboarding_success_heading).and_return(" \n text with leading and trailing whitespace \t \n ")
+      allow(Setting).to receive(:onboarding_success_text).and_return("\nSuccess text.\n")
+      is_expected.to eq("*text with leading and trailing whitespace*\n\nSuccess text.\n")
     end
   end
 end


### PR DESCRIPTION
This implements case-insenstive Threema IDs using the second suggested solution. I went with this approach, as it doesn’t require data migrations and it seemed more robust to me and the channel specific requirements are implemented in the adapter (and for example not in a `before_save` callback in the `Contributor` model). Not sure though if it’s the *best* solution.

Fixes #1347 