### PR TITLE
Remove custom PasswordsController#update method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     case_transform (0.2)
       activesupport
     chunky_png (1.4.0)
-    clearance (2.5.0)
+    clearance (2.6.0)
       actionmailer (>= 5.0)
       activemodel (>= 5.0)
       activerecord (>= 5.0)
@@ -441,4 +441,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.3.11
+   2.3.15

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -3,19 +3,4 @@
 class PasswordsController < Clearance::PasswordsController
   skip_before_action :require_login
   skip_before_action :require_otp_setup
-
-  def update
-    # This method is almost completely copied from `Clearance::PasswordsController`.
-    # However, in contrast to the parent class, it doesn't automatically sign in
-    # a user after a successful password reset.
-    @user = find_user_for_update
-
-    if @user.update_password(password_from_password_reset_params)
-      redirect_to sign_in_path
-      session[:password_reset_token] = nil
-    else
-      flash_failure_after_update
-      render template: 'passwords/edit'
-    end
-  end
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -10,6 +10,7 @@ Clearance.configure do |config|
   config.same_site = :lax
   config.redirect_url = '/dashboard'
   config.routes = false
+  config.sign_in_on_password_reset = false
 
   Rails.application.config.to_prepare do
     Clearance::BaseController.layout 'minimal'


### PR DESCRIPTION
We previously had to overwrite Clearance’s passwords controller to prevent useres being signed in automatically after resetting their password. (We don’t want that behavior, as it could be used to circumvent 2FA.)

Clearance now has a configuration option to disable automatic sign-ins after password resets: https://github.com/thoughtbot/clearance/pull/969