### PR TITLE
Bump signal-cli-rest-api and add tasks to set global trust_mode config

### DIFF
--- a/ansible/roles/signal/tasks/main.yml
+++ b/ansible/roles/signal/tasks/main.yml
@@ -13,47 +13,44 @@
   set_fact:
     signal_phone_number_not_registered: "{{ response['status'] != 200 and response['json']['error'] == error_message }}"
 
-- name: Ask for captcha result
-  pause:
-    prompt: "{{ lookup('template', 'enter_captcha.j2') | trim }}"
-  register: captcha_prompt_result
-  when: signal_phone_number_not_registered
+- name: Register, verify phone number
+  block:
+    - name: Ask for captcha result
+      pause:
+        prompt: "{{ lookup('template', 'enter_captcha.j2') | trim }}"
+      register: captcha_prompt_result
 
-- name: Set captcha result
-  set_fact:
-    captcha: "{{ captcha_prompt_result.user_input }}"
-  when: signal_phone_number_not_registered
+    - name: Set captcha result
+      set_fact:
+        captcha: "{{ captcha_prompt_result.user_input }}"
 
-- name: Register phone number
-  uri:
-    url: "{{ signal_cli_rest_api_endpoint }}/v1/register/{{ signal_server_phone_number }}"
-    method: POST
-    status_code: 201
-    body_format: json
-    body:
-      captcha: "{{ captcha }}"
-      use_voice: true
-  when: signal_phone_number_not_registered
+    - name: Register phone number
+      uri:
+        url: "{{ signal_cli_rest_api_endpoint }}/v1/register/{{ signal_server_phone_number }}"
+        method: POST
+        status_code: 201
+        body_format: json
+        body:
+          captcha: "{{ captcha }}"
+          use_voice: true
 
-- name: Ask for verification token
-  pause:
-    prompt: "{{ lookup('template', 'enter_verification_token.j2') | trim }}"
-  register: verification_token_prompt_result
-  when: signal_phone_number_not_registered
+    - name: Ask for verification token
+      pause:
+        prompt: "{{ lookup('template', 'enter_verification_token.j2') | trim }}"
+      register: verification_token_prompt_result
 
-- name: Set verification token
-  set_fact:
-    verification_token: "{{ verification_token_prompt_result.user_input }}"
-  when: signal_phone_number_not_registered
+    - name: Set verification token
+      set_fact:
+        verification_token: "{{ verification_token_prompt_result.user_input }}"
 
-- name: Verify phone number
-  uri:
-    url: "{{ signal_cli_rest_api_endpoint }}/v1/register/{{ signal_server_phone_number }}/verify/{{ verification_token }}"
-    method: POST
-    status_code: 201
-    body_format: json
-    body:
-      ping: "string"
+    - name: Verify phone number
+      uri:
+        url: "{{ signal_cli_rest_api_endpoint }}/v1/register/{{ signal_server_phone_number }}/verify/{{ verification_token }}"
+        method: POST
+        status_code: 201
+        body_format: json
+        body:
+          ping: "string"
   when: signal_phone_number_not_registered
 
 - name: Set trust mode to always

--- a/ansible/roles/signal/tasks/main.yml
+++ b/ansible/roles/signal/tasks/main.yml
@@ -14,7 +14,7 @@
     body_format: json
     body:
       captcha: "{{ captcha }}"
-      # use_voice: true
+      use_voice: true
 
 - pause:
     prompt: "{{ lookup('template', 'enter_verification_token.j2') | trim }}"

--- a/ansible/roles/signal/tasks/main.yml
+++ b/ansible/roles/signal/tasks/main.yml
@@ -14,7 +14,7 @@
     body_format: json
     body:
       captcha: "{{ captcha }}"
-      use_voice: true
+      # use_voice: true
 
 - pause:
     prompt: "{{ lookup('template', 'enter_verification_token.j2') | trim }}"
@@ -32,9 +32,24 @@
     body:
       ping: "string"
 
+- name: Set trust mode to always
+  uri:
+    url: "{{ signal_cli_rest_api_endpoint }}/v1/configuration/{{ signal_server_phone_number }}/settings"
+    method: POST
+    status_code: 204
+    body_format: json
+    body:
+      trust_mode: "always"
+
+- name: Get trust mode
+  uri:
+    url: "{{ signal_cli_rest_api_endpoint }}/v1/configuration/{{ signal_server_phone_number }}/settings"
+    method: GET
+    status_code: 200
+    body_format: json
+
 - name: Setup cronjob to receive messages
   ansible.builtin.cron:
     name: "Receive signal messages"
     minute: "*" # job gets run every minute
     job: "/usr/local/bin/docker-compose -f /home/ansible/docker-compose.yml -f /home/ansible/docker-compose.prod.yml exec -T app bin/rails signal:receive_messages"
-

--- a/ansible/roles/signal/tasks/main.yml
+++ b/ansible/roles/signal/tasks/main.yml
@@ -1,10 +1,28 @@
 ---
-- pause:
+- name: Check if signal_server_phone_number is registered
+  uri:
+    url: "{{ signal_cli_rest_api_endpoint }}/v1/receive/{{ signal_server_phone_number }}"
+  ignore_errors: true
+  register: response
+
+- name: Set error message
+  set_fact:
+    error_message: "User {{ signal_server_phone_number }} is not registered.\n"
+
+- name: Set signal_phone_number_not_registered variable
+  set_fact:
+    signal_phone_number_not_registered: "{{ response['status'] != 200 and response['json']['error'] == error_message }}"
+
+- name: Ask for captcha result
+  pause:
     prompt: "{{ lookup('template', 'enter_captcha.j2') | trim }}"
   register: captcha_prompt_result
+  when: signal_phone_number_not_registered
 
-- set_fact:
+- name: Set captcha result
+  set_fact:
     captcha: "{{ captcha_prompt_result.user_input }}"
+  when: signal_phone_number_not_registered
 
 - name: Register phone number
   uri:
@@ -15,13 +33,18 @@
     body:
       captcha: "{{ captcha }}"
       use_voice: true
+  when: signal_phone_number_not_registered
 
-- pause:
+- name: Ask for verification token
+  pause:
     prompt: "{{ lookup('template', 'enter_verification_token.j2') | trim }}"
   register: verification_token_prompt_result
+  when: signal_phone_number_not_registered
 
-- set_fact:
+- name: Set verification token
+  set_fact:
     verification_token: "{{ verification_token_prompt_result.user_input }}"
+  when: signal_phone_number_not_registered
 
 - name: Verify phone number
   uri:
@@ -31,6 +54,7 @@
     body_format: json
     body:
       ping: "string"
+  when: signal_phone_number_not_registered
 
 - name: Set trust mode to always
   uri:
@@ -40,13 +64,6 @@
     body_format: json
     body:
       trust_mode: "always"
-
-- name: Get trust mode
-  uri:
-    url: "{{ signal_cli_rest_api_endpoint }}/v1/configuration/{{ signal_server_phone_number }}/settings"
-    method: GET
-    status_code: 200
-    body_format: json
 
 - name: Setup cronjob to receive messages
   ansible.builtin.cron:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   signal:
-    image: bbernhard/signal-cli-rest-api:0.59
+    image: bbernhard/signal-cli-rest-api:0.60
     environment:
       - USE_NATIVE=0
         #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)


### PR DESCRIPTION
Built and deployed this on staging. Ran the play locally and got these results:

### POST:
![Screenshot from 2022-06-28 16-53-40](https://user-images.githubusercontent.com/26943915/176222740-14bfc8a8-033d-4c77-9c0d-274dee21da96.png)

### GET:
![Screenshot from 2022-06-28 16-54-06](https://user-images.githubusercontent.com/26943915/176222746-fffe3e10-d299-4d0d-b7a2-c2a19e1cc776.png)

Sending still failed to the `UNTRUSTED` contributor, manually sending to that contributor with the `--trust-new-identities=always` flag also fails with:

```
Failed to send (some) messages:
+4915735994012: Unregistered user "+4915735994012"
```

