### PR TITLE
chore(deps): update alpine, keep postgres-12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.2-alpine3.12
+FROM ruby:3.0.2-alpine3.14
 
 ARG git_commit_sha
 ARG git_commit_date
@@ -10,14 +10,17 @@ RUN apk --update add \
     git \
     nodejs \
     npm \
-    postgresql-dev=~12 \
-    postgresql-client=~12 \
     tzdata \
     libxslt-dev \
     libxml2-dev \
     imagemagick \
     less \
     libsodium
+
+RUN apk --update add \
+    postgresql-dev=~12 \
+    postgresql-client=~12 \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main
 
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh


### PR DESCRIPTION
Install it from from the 3.12 repository according to this stackoverflow link:
https://stackoverflow.com/a/63976418/2069431

I don't know if this is considered bad practice though. But that should
fix our immediate problem.

close #1411
