### PR TITLE
Rescue Postmark::InactiveRecipientError and tag with support

### DIFF
--- a/app/adapters/postmark_adapter/outbound.rb
+++ b/app/adapters/postmark_adapter/outbound.rb
@@ -10,7 +10,11 @@ module PostmarkAdapter
     def self.send!(message)
       return unless message.recipient&.email
 
-      with(message: message).message_email.deliver_later
+      begin
+        with(message: message).message_email.deliver_later
+      rescue Postmark::InactiveRecipientError => e
+        ErrorNotifier.report(e, context: { recipients: e.recipients }, tags: { type: 'support' })
+      end
     end
 
     def self.send_welcome_message!(contributor)

--- a/app/adapters/postmark_adapter/outbound.rb
+++ b/app/adapters/postmark_adapter/outbound.rb
@@ -5,16 +5,16 @@ module PostmarkAdapter
     default template_name: :mailer
     default from: -> { default_from }
 
+    rescue_from Postmark::InactiveRecipientError do |exception|
+      ErrorNotifier.report(exception, context: { recipients: exception.recipients }, tags: { support: 'yes' })
+    end
+
     attr_reader :msg
 
     def self.send!(message)
       return unless message.recipient&.email
 
-      begin
-        with(message: message).message_email.deliver_later
-      rescue Postmark::InactiveRecipientError => e
-        ErrorNotifier.report(e, context: { recipients: e.recipients }, tags: { type: 'support' })
-      end
+      with(message: message).message_email.deliver_later
     end
 
     def self.send_welcome_message!(contributor)

--- a/app/lib/error_notifier.rb
+++ b/app/lib/error_notifier.rb
@@ -2,9 +2,10 @@
 
 class ErrorNotifier
   class << self
-    def report(exception, context: {})
+    def report(exception, context: {}, tags: {})
       Sentry.with_scope do |scope|
         scope.set_context(exception, context) if context.present?
+        scope.set_tags(tags) if tags.present?
         Sentry.capture_exception(exception)
       end
     end

--- a/spec/adapters/postmark_adapter/outbound_spec.rb
+++ b/spec/adapters/postmark_adapter/outbound_spec.rb
@@ -165,46 +165,6 @@ RSpec.describe PostmarkAdapter::Outbound, type: :mailer do
           }
         )
       end
-
-      context 'with an inactive recipient' do
-        let(:action_mailer) { instance_double(ActionMailer::MessageDelivery) }
-        let(:action_mailer_parameterized) { double(ActionMailer::Parameterized::Mailer) }
-        let(:error_message) do
-          "You tried to send to recipient(s) that have been marked as inactive.\n" \
-            "Found inactive addresses: #{contributor.email}.\n" \
-            'Inactive recipients are ones that have generated a hard bounce, a spam complaint, or a manual suppression.'
-        end
-        let(:parsed_body) { { 'ErrorCode' => 406, 'Message' => error_message } }
-        let(:body) { Postmark::Json.encode(parsed_body) }
-        let(:postmark_inactive_recipient_error) { Postmark::InactiveRecipientError.new(parsed_body['ErrorCode'], body, parsed_body) }
-
-        before do
-          allow(PostmarkAdapter::Outbound).to receive(:with).with({ message: message }).and_return(action_mailer_parameterized)
-          allow(action_mailer_parameterized).to receive(:message_email).and_return(action_mailer)
-          allow(action_mailer).to receive(:deliver_later).and_raise(postmark_inactive_recipient_error)
-        end
-
-        describe 'calls ErrorNotifier' do
-          before { allow(ErrorNotifier).to receive(:report) }
-
-          it 'with context and tags' do
-            subject
-
-            expect(ErrorNotifier).to have_received(:report).with(postmark_inactive_recipient_error,
-                                                                 context: { recipients: [contributor.email] }, tags: { type: 'support' })
-          end
-        end
-
-        describe 'reports error to Sentry' do
-          before { allow(Sentry).to receive(:capture_exception) }
-
-          it 'capture_exception' do
-            subject
-
-            expect(Sentry).to have_received(:capture_exception).with(postmark_inactive_recipient_error)
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Closes #1382

- [x] Add custom tag to Postmark::InactiveRecipientError events
- [x] Edit Alert rule in Sentry to stop reporting events with the tag `support: yes`
- [x] Create #support channel in Slack and add @FrauCsu and @drjakob 
- [x] Create Alert rule in Sentry to report these events to the #support channel in Slack
- [x] Manually test on staging.100ey.es