### PR TITLE
Add missing strong tag in notifications feed

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -719,7 +719,7 @@ de:
     message_received:
       text_html:
         one: "<strong>%{contributor_one}</strong> hat auf die Frage <strong>„%{request_title}”</strong> geantwortet."
-        two: "<strong>%{contributor_one}</strong> und %{contributor_two} haben auf die Frage <strong>„%{request_title}”</strong> geantwortet."
+        two: "<strong>%{contributor_one}</strong> und <strong>%{contributor_two}</strong> haben auf die Frage <strong>„%{request_title}”</strong> geantwortet."
         other: "<strong>%{contributor_one}</strong> und %{others_count} andere haben auf die Frage <strong>„%{request_title}”</strong> geantwortet."
       link_text: "Zur Antwort"
     chat_message_sent:


### PR DESCRIPTION
Was an oversight that I caught when manually testing on staging.100ey.es