### PR TITLE
Sanitize tag names in tags input

### DIFF
--- a/app/components/tags_input/tags_input.js
+++ b/app/components/tags_input/tags_input.js
@@ -7,11 +7,17 @@ const tagColor = tagData => {
 };
 
 function tagTemplate(tagData) {
-  const color = tagColor(tagData);
-
   // This is a simplified copy of the default template that ships with
   // Tagify. The main difference is that tag names are sanitized before
   // being rendered.
+
+  const color = tagColor(tagData);
+
+  // `tagData.name` is an unsanitized tag name from our database.
+  // `tagData.value` is provided by Tagify and has already been sanitized.
+  // https://github.com/yairEO/tagify/blob/8a9efbd680dc05f3f398bf91025f949a69551fbf/src/tagify.js#L1443
+  const label = sanitize(tagData.name) || tagData.value;
+
   return `
     <tag
       tabIndex="-1"
@@ -25,9 +31,7 @@ function tagTemplate(tagData) {
         aria-label="remove tag"
       ></x>
       <div>
-        <span class="tagify__tag-text">${
-          sanitize(tagData.name) || sanitize(tagData.value)
-        }</span>
+        <span class="tagify__tag-text">${label}</span>
       </div>
     </tag>
   `;

--- a/app/components/tags_input/tags_input.js
+++ b/app/components/tags_input/tags_input.js
@@ -1,9 +1,37 @@
 import { Controller } from '@hotwired/stimulus';
 import Tagify from '@yaireo/tagify';
+import sanitize from '../../assets/javascript/helpers/sanitize.js';
 
 const tagColor = tagData => {
   return tagData.color ? tagData.color : 'var(--color-text)';
 };
+
+function tagTemplate(tagData) {
+  const color = tagColor(tagData);
+
+  // This is a simplified copy of the default template that ships with
+  // Tagify. The main difference is that tag names are sanitized before
+  // being rendered.
+  return `
+    <tag
+      tabIndex="-1"
+      class="tagify__tag"
+      style="--tag-color:${tagColor(tagData)}"
+    >
+      <x
+        title=""
+        class="tagify__tag__removeBtn"
+        role="button"
+        aria-label="remove tag"
+      ></x>
+      <div>
+        <span class="tagify__tag-text">${
+          sanitize(tagData.name) || sanitize(tagData.value)
+        }</span>
+      </div>
+    </tag>
+  `;
+}
 
 function dropdownItemTemplate(tagData) {
   const { one, other } = this.settings.labels.members;
@@ -11,25 +39,19 @@ function dropdownItemTemplate(tagData) {
   const color = tagColor(tagData);
 
   return `
-    <div ${this.getAttributes(tagData)}
+    <div
       class="${this.settings.classNames.dropdownItem} TagsInput-dropdownItem"
       tabindex="0"
       role="option"
     >
       <span class="tagify__tag" style="--tag-color: ${color}">
         <div>
-          <span class="tagify__tag-text">${tagData.name}</span>
+          <span class="tagify__tag-text">${sanitize(tagData.name)}</span>
         </div>
       </span>
       <span class="TagsInput-count">${tagData.count} ${membersLabel}<span>
     </div>
   `;
-}
-
-function transformTag(tagData) {
-  const color = tagColor(tagData);
-
-  tagData.style = `--tag-color: ${color}`;
 }
 
 export default class extends Controller {
@@ -60,9 +82,9 @@ export default class extends Controller {
 
       templates: {
         dropdownItem: dropdownItemTemplate,
+        tag: tagTemplate,
       },
 
-      transformTag,
       labels: {
         members: JSON.parse(this.membersLabelValue),
       },


### PR DESCRIPTION
Previously, if a user created a tag like…

```
<script>alert('Hello World')</script>
<img src="https://example.org/ping" />
```

… that would actually get rendered. Thankfully, we have a very restrictive CSP in place that prevents execution of inline and third-party JS as well as loading third-party images. So while the markup would get rendered, no scripts and no images would actually be executed or loaded. Furthermore, only authenticated editors are able to assign and create tags.