### PR TITLE
Set timeout to avoid long stalled test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     env:
       RUBYOPT: "-W:no-deprecated"


### PR DESCRIPTION
I noticed that we had some test runs that went for `6h`, we should avoid this by setting a timeout so that we don't use all our minutes on stalled runs.

Actually, it seems that public repos don't have a limit of free minutes. Maybe, it is still a good idea to time out after some time though? We do have a limit on concurrent jobs.