### PR TITLE
Configure dependabot to ignore patch version updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,30 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Currently, the maintenance overhead for merging dependabot updates is quite high, especially considering the few active maintainers. This PR proposes reducing maintenance overhead for merging in multiple patch updates per minor version, security updates are not affected by this change.