### PR TITLE
Rescue RuntimeError and mark as support conditionally

### DIFF
--- a/app/adapters/threema_adapter/outbound.rb
+++ b/app/adapters/threema_adapter/outbound.rb
@@ -4,6 +4,11 @@ module ThreemaAdapter
   class Outbound < ApplicationJob
     queue_as :default
 
+    rescue_from RuntimeError do |exception|
+      tags = exception.message.match?(/Can't find public key for Threema ID/) ? { support: 'yes' } : {}
+      ErrorNotifier.report(exception, tags: tags)
+    end
+
     def self.threema_instance
       @threema_instance ||= Threema.new
     end


### PR DESCRIPTION
Closes #1448 

- If the RuntimeError happened because of a failed public key lookup, we mark it with support to send it to the #support slack channel, but other RuntimeError, we continue to send to the #monitoring channel