### PR TITLE
Add additional context to SignalAdapter::CreateContactJob errors

### DIFF
--- a/app/jobs/signal_adapter/create_contact_job.rb
+++ b/app/jobs/signal_adapter/create_contact_job.rb
@@ -20,6 +20,13 @@ module SignalAdapter
         http.request(req)
       end
       res.value
+    rescue Net::HTTPServerException => e
+      ErrorNotifier.report(e, context: {
+                             code: e.response.code,
+                             message: e.response.message,
+                             headers: e.response.to_hash,
+                             body: e.response.body
+                           })
     end
   end
 end


### PR DESCRIPTION
-  to help save time with debugging.

Closes #1505 