### PR TITLE
Avoid reliance on project name for legacy messages

### DIFF
--- a/app/components/chat_message/chat_message.html.erb
+++ b/app/components/chat_message/chat_message.html.erb
@@ -87,7 +87,11 @@
 
     <footer class="ChatMessage-footer">
       <p class="ChatMessage-senderNameMessageUpdatedAt">
-        <%= t('.sent_by_x_at', name: message.sender ? message.sender.first_name : Setting.project_name, date: date_time(message.updated_at)).html_safe %>
+        <% if message.sender %>
+          <%= t('.sent_by_x_at', name:message.sender.first_name, date: date_time(message.updated_at)).html_safe %>
+        <% else %>
+          <time><%= date_time(message.updated_at) %></time>
+        <% end %>
       </p>
       <% unless hide_actions %>
         <%= c 'copy_button',


### PR DESCRIPTION
- At this moment, the majority of all instances outbound messages, we don't know who sent. I originally was relying on the project name to display something, but not all instances have project names, or some might be super long, so we just display the date