### PR TITLE
Favor unique identifier for group key to fix bug

### DIFF
--- a/app/activity_notifications/chat_message_sent.rb
+++ b/app/activity_notifications/chat_message_sent.rb
@@ -16,7 +16,8 @@ class ChatMessageSent < Noticed::Base
   end
 
   def group_key
-    [record.request_id, record.user_id]
+    [{ "#{self.class.to_s.underscore}_request_id".to_sym => record.request_id },
+     { "#{self.class.to_s.underscore}_user_id".to_sym => record.user_id }]
   end
 
   def record_for_avatar

--- a/app/activity_notifications/message_received.rb
+++ b/app/activity_notifications/message_received.rb
@@ -15,7 +15,7 @@ class MessageReceived < Noticed::Base
   end
 
   def group_key
-    record.request_id
+    { "#{self.class.to_s.underscore}_request_id".to_sym => record.request_id }
   end
 
   def record_for_avatar

--- a/app/activity_notifications/onboarding_completed.rb
+++ b/app/activity_notifications/onboarding_completed.rb
@@ -13,7 +13,7 @@ class OnboardingCompleted < Noticed::Base
   end
 
   def group_key
-    record.contributor_id
+    { "#{self.class.to_s.underscore}_contributor_id".to_sym => record.contributor_id }
   end
 
   def record_for_avatar


### PR DESCRIPTION
Closes #1526 

## Notes to reproduce

1. Start from an instance that has no requests or contributors.
2. Onboard yourself with one or more channels.
3. Send out a request.
4. Go to the /dashboard and see that only the request notification is present.

If the contributor id and the request id are the same as in the example :point_up_2:, then the notifications have been grouped together and only the latest(the request) is shown in the activity feed.

This PR uses the notifications class name, plus the name of the record whose id is being used to group. This ensures that even if two different notification events group by the same record's id, they will not be grouped as they are not from the same event.