### PR TITLE
Upgrade signal-cli-rest-api, which includes bug fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   signal:
-    image: bbernhard/signal-cli-rest-api:0.63
+    image: bbernhard/signal-cli-rest-api:0.64
     environment:
       - USE_NATIVE=0
         #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)


### PR DESCRIPTION
- v0.63 included a temp bug fix for https://github.com/bbernhard/signal-cli-rest-api/issues/286. v0.64 is a more permanent fix, but also upgrades signal-cli to by a major version so we should test properly before merging and deploying

Closes #1535 