### PR TITLE
Extend signal allowed audio types

### DIFF
--- a/app/adapters/signal_adapter/inbound.rb
+++ b/app/adapters/signal_adapter/inbound.rb
@@ -7,7 +7,7 @@ module SignalAdapter
 
   class Inbound
     UNKNOWN_CONTENT_KEYS = %w[mentions contacts sticker].freeze
-    SUPPORTED_ATTACHMENT_TYPES = %w[image/jpg image/jpeg image/png image/gif audio/oog audio/aac audio/mp4].freeze
+    SUPPORTED_ATTACHMENT_TYPES = %w[image/jpg image/jpeg image/png image/gif audio/oog audio/aac audio/mp4 audio/mpeg].freeze
 
     attr_reader :sender, :text, :message
 

--- a/spec/adapters/signal_adapter/inbound_spec.rb
+++ b/spec/adapters/signal_adapter/inbound_spec.rb
@@ -71,18 +71,20 @@ RSpec.describe SignalAdapter::Inbound do
           message: 'Hello 100eyes',
           expiresInSeconds: 0,
           viewOnce: false,
-          attachments: [{
-            contentType: 'image/jpeg',
-            filename: 'signal-2021-09.jpeg',
-            id: 'zuNhdpIHpRU_9Du-B4oG',
-            size: 145_078
-          },
-                        {
-                          contentType: 'image/jpeg',
-                          filename: 'signal-2021-09.jpeg',
-                          id: 'zuNhdpIHpRU_9Du-B4oG',
-                          size: 115_809
-                        }]
+          attachments: [
+            {
+              contentType: 'image/jpeg',
+              filename: 'signal-2021-09.jpeg',
+              id: 'zuNhdpIHpRU_9Du-B4oG',
+              size: 145_078
+            },
+            {
+              contentType: 'image/jpeg',
+              filename: 'signal-2021-09.jpeg',
+              id: 'zuNhdpIHpRU_9Du-B4oG',
+              size: 115_809
+            }
+          ]
         }
       }
     }
@@ -288,6 +290,16 @@ RSpec.describe SignalAdapter::Inbound do
 
           it 'preserves the content_type' do
             expect(subject.blob.content_type).to eq('audio/aac')
+          end
+        end
+
+        context 'given an audio/mpeg file' do
+          before { signal_message[:envelope][:dataMessage][:attachments][0][:contentType] = 'audio/mpeg' }
+
+          it { should be_attached }
+
+          it 'preserves the content_type' do
+            expect(subject.blob.content_type).to eq('audio/mpeg')
           end
         end
 


### PR DESCRIPTION
- signal desktop seems to send audio/mpeg files and these were not accepted

Fixes #1540 