### PR TITLE
Conditionally render our Pagination component

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,6 +6,27 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
-<%= paginator.render do -%>
-  <%= c 'pagination', current_page: current_page, remote: remote, pages: each_page, path: params[:path] %>
-<% end -%>
+<% if params[:path] %>
+  <%= paginator.render do -%>
+    <%= c 'pagination', current_page: current_page, remote: remote, pages: each_page, path: params[:path] %>
+  <% end -%>
+<% else %>
+  <%# administrate gem uses kaminari under the hood and trying to render our component results in an error: undefined method `c' for #<Kaminari::Helpers::Paginator %>
+  <%= paginator.render do -%>
+    <nav class="pagination" role="navigation" aria-label="pager">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+        <%= last_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  <% end -%>
+<% end %>


### PR DESCRIPTION
Fixes #1595 

I looked into a way to include our **ComponentHelper** in the Admin Controllers, but I didn't have any luck. Also, I don't this we care too much about how the pagination looks in admin, we can use default styles. This checks if a `params[:path]` is passed in, which would be required for any other pages we might want to add pagination to.