### PR TITLE
Refactor to favor  a request's broadcasted_at over created_at

### DIFF
--- a/app/activity_notifications/request_scheduled.rb
+++ b/app/activity_notifications/request_scheduled.rb
@@ -32,7 +32,12 @@ class RequestScheduled < Noticed::Base
   # rubocop:enable Rails/OutputSafety
 
   def url
-    requests_path(filter: :planned, anchor: "request-#{record.request_id}")
+    filter = if record.request.broadcasted_at.present?
+               :sent
+             else
+               :planned
+             end
+    requests_path(filter: filter, anchor: "request-#{record.request_id}")
   end
 
   def link_text

--- a/app/components/move_message_form/move_message_form.rb
+++ b/app/components/move_message_form/move_message_form.rb
@@ -18,8 +18,8 @@ module MoveMessageForm
 
     def recent_requests
       Request
-        .where('created_at <= ?', request.created_at)
-        .order(created_at: :desc)
+        .where('broadcasted_at <= ?', request.broadcasted_at)
+        .order(broadcasted_at: :desc)
         .limit(5)
     end
 
@@ -28,7 +28,7 @@ module MoveMessageForm
         {
           value: request.id,
           label: request.title,
-          help: "Frage gestellt #{date_time(request.created_at)}"
+          help: "Frage gestellt #{date_time(request.broadcasted_at)}"
         }
       end
     end

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -38,10 +38,11 @@ class ChartsController < ApplicationController
   end
 
   def group_messages(messages, group_keys)
-    messages = messages.group_by_day_of_week(:created_at, format: '%A', week_start: :monday) if group_keys.include?(:day_of_week)
+    column = messages.all? { |message| message.is_a? Request } ? :broadcasted_at : :created_at
+    messages = messages.group_by_day_of_week(column, format: '%A', week_start: :monday) if group_keys.include?(:day_of_week)
     return messages unless group_keys.include?(:hour_of_day)
 
-    messages.group_by_hour_of_day(:created_at, format: '%H:%M')
+    messages.group_by_hour_of_day(column, format: '%H:%M')
   end
 
   def day_and_time_data(messages, day)

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -38,6 +38,8 @@ class ChartsController < ApplicationController
   end
 
   def group_messages(messages, group_keys)
+    return [] unless messages.any?
+
     column = messages.all? { |message| message.is_a? Request } ? :broadcasted_at : :created_at
     messages = messages.group_by_day_of_week(column, format: '%A', week_start: :monday) if group_keys.include?(:day_of_week)
     return messages unless group_keys.include?(:hour_of_day)

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -8,7 +8,7 @@ class RequestsController < ApplicationController
 
   def index
     @filter = filter_param
-    @sent_requests_count = Request.include_associations.sent.count
+    @sent_requests_count = Request.include_associations.broadcasted_at.count
     @planned_requests_count = Request.include_associations.planned.count
     @requests = filtered_requests.page(params[:page])
   end
@@ -111,6 +111,10 @@ class RequestsController < ApplicationController
   end
 
   def filtered_requests
-    @filter == :planned ? Request.reorder(schedule_send_for: :desc).include_associations.planned : Request.include_associations.sent
+    if @filter == :planned
+      Request.planned.reorder(schedule_send_for: :desc).include_associations
+    else
+      Request.broadcasted_at.include_associations
+    end
   end
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -8,7 +8,7 @@ class RequestsController < ApplicationController
 
   def index
     @filter = filter_param
-    @sent_requests_count = Request.include_associations.broadcasted_at.count
+    @sent_requests_count = Request.include_associations.broadcasted.count
     @planned_requests_count = Request.include_associations.planned.count
     @requests = filtered_requests.page(params[:page])
   end
@@ -114,7 +114,7 @@ class RequestsController < ApplicationController
     if @filter == :planned
       Request.planned.reorder(schedule_send_for: :desc).include_associations
     else
-      Request.broadcasted_at.include_associations
+      Request.broadcasted.include_associations
     end
   end
 end

--- a/app/dashboards/request_dashboard.rb
+++ b/app/dashboards/request_dashboard.rb
@@ -9,6 +9,7 @@ class RequestDashboard < Administrate::BaseDashboard
     text: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
+    broadcasted_at: Field::DateTime,
     messages: Field::HasMany
   }.freeze
 
@@ -16,6 +17,7 @@ class RequestDashboard < Administrate::BaseDashboard
     id
     title
     created_at
+    broadcasted_at
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
@@ -24,6 +26,7 @@ class RequestDashboard < Administrate::BaseDashboard
     text
     created_at
     updated_at
+    broadcasted_at
     messages
   ].freeze
 

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -14,7 +14,7 @@ class Contributor < ApplicationRecord
   has_many :replies, class_name: 'Message', as: :sender, dependent: :destroy
   has_many :received_messages, class_name: 'Message', inverse_of: :recipient, foreign_key: 'recipient_id', dependent: :destroy
   has_many :replied_to_requests, -> { reorder(created_at: :desc).distinct }, source: :request, through: :replies
-  has_many :received_requests, -> { reorder(created_at: :desc).distinct }, source: :request, through: :received_messages
+  has_many :received_requests, -> { reorder(broadcasted_at: :desc).distinct }, source: :request, through: :received_messages
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy
   belongs_to :organization, optional: true
   belongs_to :deactivated_by_user, class_name: 'User', optional: true
@@ -113,7 +113,7 @@ class Contributor < ApplicationRecord
   end
 
   def active_request
-    received_requests.reorder(created_at: :desc).first || Request.reorder(created_at: :desc).first
+    received_requests.reorder(broadcasted_at: :desc).first || Request.reorder(broadcasted_at: :desc).first
   end
 
   def telegram?

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -14,7 +14,7 @@ class Contributor < ApplicationRecord
   has_many :replies, class_name: 'Message', as: :sender, dependent: :destroy
   has_many :received_messages, class_name: 'Message', inverse_of: :recipient, foreign_key: 'recipient_id', dependent: :destroy
   has_many :replied_to_requests, -> { reorder(created_at: :desc).distinct }, source: :request, through: :replies
-  has_many :received_requests, -> { reorder(broadcasted_at: :desc).distinct }, source: :request, through: :received_messages
+  has_many :received_requests, -> { broadcasted.reorder(broadcasted_at: :desc).distinct }, source: :request, through: :received_messages
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy
   belongs_to :organization, optional: true
   belongs_to :deactivated_by_user, class_name: 'User', optional: true
@@ -113,7 +113,7 @@ class Contributor < ApplicationRecord
   end
 
   def active_request
-    received_requests.reorder(broadcasted_at: :desc).first || Request.reorder(broadcasted_at: :desc).first
+    received_requests.first || Request.broadcasted.first
   end
 
   def telegram?

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -7,7 +7,7 @@ class Request < ApplicationRecord
   has_many :messages, dependent: :destroy
   has_many :contributors, through: :messages, source: :recipient
   has_many :photos, through: :messages
-  default_scope { order(created_at: :desc) }
+  default_scope { order(broadcasted_at: :desc) }
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy
   has_many_attached :files
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -13,7 +13,7 @@ class Request < ApplicationRecord
 
   scope :include_associations, -> { preload(messages: :sender).includes(messages: :files).eager_load(:messages) }
   scope :planned, -> { where.not(schedule_send_for: nil).where('schedule_send_for > ?', Time.current) }
-  scope :sent, -> { where(schedule_send_for: nil).or(where('schedule_send_for < ?', Time.current)) }
+  scope :broadcasted, -> { where.not(broadcasted_at: nil) }
 
   validates :files, blob: { content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'] }
   validates :title, presence: true

--- a/spec/components/move_message_form_spec.rb
+++ b/spec/components/move_message_form_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe MoveMessageForm::MoveMessageForm, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
-  let!(:older_request) { create(:request, created_at: 1.hour.ago) }
-  let!(:current_request) { create(:request, created_at: 0.hours.ago) }
-  let!(:newer_request) { create(:request, created_at: 1.hour.from_now) }
+  let!(:older_request) { create(:request, broadcasted_at: 1.hour.ago) }
+  let!(:current_request) { create(:request, broadcasted_at: 0.hours.ago) }
+  let!(:planned_request) { create(:request, broadcasted_at: 1.hour.from_now) }
 
   let(:message) { create(:message, request: current_request) }
 
@@ -30,8 +30,8 @@ RSpec.describe MoveMessageForm::MoveMessageForm, type: :component do
     expect(last[:checked]).to be_nil
   end
 
-  it 'does not show newer request' do
+  it 'does not show planned request' do
     request_ids = subject.css('input[type="radio"]').pluck(:value)
-    expect(request_ids).not_to include(newer_request.id)
+    expect(request_ids).not_to include(planned_request.id)
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :request do
     title { 'I need a title' }
     text { 'I am a request' }
+    broadcasted_at { Time.current }
     user
 
     trait :with_interlapping_messages_from_two_contributors do

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -530,8 +530,8 @@ RSpec.describe Contributor, type: :model do
       it { should eq(the_request) }
     end
 
-    describe 'if a request was created' do
-      before(:each) { the_request }
+    describe 'if a request was broadcasted' do
+      before(:each) { the_request.update(broadcasted_at: 1.day.ago) }
       describe 'and afterwards a contributor joins' do
         before(:each) { contributor }
         it { should eq(the_request) }
@@ -543,6 +543,16 @@ RSpec.describe Contributor, type: :model do
         another_request = create(:request, broadcasted_at: 1.day.ago)
         create(:message, request: the_request, recipient: contributor)
         create(:message, request: another_request, recipient: contributor)
+      end
+
+      it { should eq(the_request) }
+    end
+
+    describe 'when there is a planned request' do
+      before(:each) do
+        planned_request = create(:request, broadcasted_at: nil, schedule_send_for: 1.day.from_now)
+        create(:message, request: the_request, recipient: contributor)
+        create(:message, request: planned_request, recipient: contributor)
       end
 
       it { should eq(the_request) }

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -540,7 +540,7 @@ RSpec.describe Contributor, type: :model do
 
     describe 'when many requests are sent to the contributor' do
       before(:each) do
-        another_request = create(:request, created_at: 1.day.ago)
+        another_request = create(:request, broadcasted_at: 1.day.ago)
         create(:message, request: the_request, recipient: contributor)
         create(:message, request: another_request, recipient: contributor)
       end

--- a/spec/system/admin/auth_spec.rb
+++ b/spec/system/admin/auth_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Auth' do
       click_link 'Admin'
 
       expect(page).to have_http_status(:ok)
+
       expect(page).to have_link('New user')
     end
   end


### PR DESCRIPTION
Closes https://github.com/tactilenews/100eyes-closed/issues/217

Originally, created_at and broadcasted_at were virtually identical as we would create the request and call `#broadcast!` in an `after_create_commit`, but since the additiona of [Schedule requests to be delivered in future #1581](https://github.com/tactilenews/100eyes/pull/1581), we allow the ability to schedule requests and keep track of when they were actually broadcast.