### PR TITLE
Fix bug where latest message not sent with edge case

### DIFF
--- a/app/adapters/whats_app_adapter/inbound.rb
+++ b/app/adapters/whats_app_adapter/inbound.rb
@@ -63,7 +63,7 @@ module WhatsAppAdapter
     def initialize_message(whats_app_message)
       message_text = whats_app_message[:body]
 
-      trigger(RESPONDING_TO_TEMPLATE_MESSAGE, sender, message_text) if sender.whats_app_template_message_sent_at.present?
+      trigger(RESPONDING_TO_TEMPLATE_MESSAGE, sender, message_text) if quick_reply_response?(message_text)
       trigger(UNSUBSCRIBE_CONTRIBUTOR, sender) if unsubscribe_text?(message_text)
       trigger(SUBSCRIBE_CONTRIBUTOR, sender) if subscribe_text?(message_text)
       message = Message.new(text: message_text, sender: sender)

--- a/app/adapters/whats_app_adapter/outbound.rb
+++ b/app/adapters/whats_app_adapter/outbound.rb
@@ -76,8 +76,6 @@ module WhatsAppAdapter
       end
 
       def send_message_template(recipient, message)
-        recipient.update(whats_app_template_message_sent_at: Time.current)
-
         text = I18n.t("adapter.whats_app.request_template.new_request_#{time_of_day}_#{rand(1..3)}", first_name: recipient.first_name,
                                                                                                      request_title: message.request.title)
         WhatsAppAdapter::Outbound::Text.perform_later(recipient: recipient, text: text)

--- a/app/controllers/whats_app/webhook_controller.rb
+++ b/app/controllers/whats_app/webhook_controller.rb
@@ -78,7 +78,7 @@ module WhatsApp
     end
 
     def handle_respond_to_template_message(contributor, text)
-      contributor.update!(whats_app_message_template_responded_at: Time.current, whats_app_template_message_sent_at: nil)
+      contributor.update!(whats_app_message_template_responded_at: Time.current)
 
       if text.strip.eql?(I18n.t('adapter.whats_app.quick_reply_button_text.more_info'))
         WhatsAppAdapter::Outbound.send_more_info_message!(contributor)

--- a/db/migrate/20230616105358_remove_whats_app_message_template_attrs_from_contributor.rb
+++ b/db/migrate/20230616105358_remove_whats_app_message_template_attrs_from_contributor.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveWhatsAppMessageTemplateAttrsFromContributor < ActiveRecord::Migration[6.1]
+  def up
+    change_table(:contributors, bulk: true) do |t|
+      t.remove :whats_app_template_message_sent_at
+    end
+  end
+
+  def down
+    change_table(:contributors, bulk: true) do |t|
+      t.column :whats_app_template_message_sent_at, :datetime, default: nil, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_01_091224) do
+ActiveRecord::Schema.define(version: 2023_06_16_105358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -111,10 +111,9 @@ ActiveRecord::Schema.define(version: 2023_03_01_091224) do
     t.datetime "additional_consent_given_at"
     t.bigint "organization_id"
     t.string "whats_app_phone_number"
-    t.datetime "whats_app_template_message_sent_at"
-    t.datetime "whats_app_message_template_responded_at"
     t.bigint "deactivated_by_user_id"
     t.boolean "deactivated_by_admin", default: false
+    t.datetime "whats_app_message_template_responded_at"
     t.index ["email"], name: "index_contributors_on_email", unique: true
     t.index ["organization_id"], name: "index_contributors_on_organization_id"
     t.index ["signal_phone_number"], name: "index_contributors_on_signal_phone_number", unique: true

--- a/spec/adapters/whats_app_adapter/outbound_spec.rb
+++ b/spec/adapters/whats_app_adapter/outbound_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe WhatsAppAdapter::Outbound do
         end
       end
 
-      describe 'contributor has sent a reply within 24 hours with no template being sent' do
+      describe 'contributor has sent a reply within 24 hours' do
         before { create(:message, sender: contributor) }
 
         it 'enqueues the Text job with the request text' do
@@ -117,7 +117,7 @@ RSpec.describe WhatsAppAdapter::Outbound do
         it { is_expected.to eq(true) }
       end
 
-      context 'contributor has not responded' do
+      context 'contributor has not responded, and has no messages within 24 hours' do
         it { is_expected.to eq(false) }
       end
     end

--- a/spec/requests/whats_app/webhook_spec.rb
+++ b/spec/requests/whats_app/webhook_spec.rb
@@ -84,12 +84,8 @@ RSpec.describe WhatsApp::WebhookController do
       end
 
       context 'responding to template' do
-        before { contributor.update(whats_app_template_message_sent_at: Time.current) }
+        before { params['Body'] = 'Antworten' }
         let(:expected_job_args) { { recipient: contributor, text: contributor.received_messages.first.text } }
-
-        it 'set `whats_app_template_message_sent_at` to nil' do
-          expect { subject.call }.to change { contributor.reload.whats_app_template_message_sent_at }.from(kind_of(Time)).to(nil)
-        end
 
         it 'enqueues a job to send the latest received message' do
           expect { subject.call }.to have_enqueued_job(WhatsAppAdapter::Outbound::Text).on_queue('default').with(expected_job_args)


### PR DESCRIPTION
- If a contributor uses the quick reply to ask for more info and then decides to use the quick reply to receive the question, they would not receive anything.


Fixes #1653 