### PR TITLE
Fix request broadcasted logic

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,6 +4,8 @@ class Request < ApplicationRecord
   include PlaceholderHelper
   include PgSearch::Model
 
+  SCHEDULE_REQUEST_FEATURE_DEPLOYED_AT = Time.zone.local(2023, 1, 7, 7, 40)
+
   multisearchable against: %i[title text]
 
   belongs_to :user
@@ -16,7 +18,7 @@ class Request < ApplicationRecord
 
   scope :include_associations, -> { preload(messages: :sender).includes(messages: :files).eager_load(:messages) }
   scope :planned, -> { where.not(schedule_send_for: nil).where('schedule_send_for > ?', Time.current) }
-  scope :broadcasted, -> { where.not(broadcasted_at: nil) }
+  scope :broadcasted, -> { where.not(broadcasted_at: nil).or(where('requests.created_at <= ?', SCHEDULE_REQUEST_FEATURE_DEPLOYED_AT)) }
 
   validates :files, blob: { content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'] }
   validates :title, presence: true

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe Request, type: :model do
     end
   end
 
+  describe 'scopes' do
+    let!(:request_created_before_broadcasted_at_introduced) do
+      create(:request, created_at: Time.zone.local(2023, 1, 7, 7, 39), broadcasted_at: nil)
+    end
+    let!(:recent_request) { create(:request) }
+
+    context 'broadcasted' do
+      subject { Request.broadcasted }
+      before(:each) { allow(Request).to receive(:broadcast!).and_call_original } # is stubbed for every other test
+
+      it { is_expected.to include(recent_request) }
+      it { is_expected.to include(request_created_before_broadcasted_at_introduced) }
+    end
+  end
+
   it 'has title, text, and user_id' do
     expect(subject.attributes.keys).to include('title', 'text', 'user_id')
   end


### PR DESCRIPTION
- consider all requests created before the scheduling requests feature was deployed as broadcasted to follow logic before feature release.
 

Fixes #1671 