### PR TITLE
Favor marking legacy requests as broadcasted

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,8 +4,6 @@ class Request < ApplicationRecord
   include PlaceholderHelper
   include PgSearch::Model
 
-  SCHEDULE_REQUEST_FEATURE_DEPLOYED_AT = Time.zone.local(2023, 1, 7, 7, 40)
-
   multisearchable against: %i[title text]
 
   belongs_to :user
@@ -18,7 +16,7 @@ class Request < ApplicationRecord
 
   scope :include_associations, -> { preload(messages: :sender).includes(messages: :files).eager_load(:messages) }
   scope :planned, -> { where.not(schedule_send_for: nil).where('schedule_send_for > ?', Time.current) }
-  scope :broadcasted, -> { where.not(broadcasted_at: nil).or(where('requests.created_at <= ?', SCHEDULE_REQUEST_FEATURE_DEPLOYED_AT)) }
+  scope :broadcasted, -> { where.not(broadcasted_at: nil) }
 
   validates :files, blob: { content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'] }
   validates :title, presence: true

--- a/lib/tasks/temporary/mark_legacy_requests_as_broadcasted.rake
+++ b/lib/tasks/temporary/mark_legacy_requests_as_broadcasted.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :requests do
+  desc 'Mark legacy requests - created before schedule requests feature released - as broadcasted'
+  task mark_legacy_requests_as_broadcasted: :environment do
+    ActiveRecord::Base.transaction do
+      puts "Mark #{Request.where('created_at <= ?', Time.zone.local(2023, 1, 7, 7, 40)).count} legacy requests as broadcasted."
+      Request.where('created_at <= ?', Time.zone.local(2023, 1, 7, 7, 40)).find_each do |request|
+        created_at = request.created_at
+        request.broadcasted_at = created_at
+        request.save!(validate: false)
+        print '.'
+      end
+    end
+  end
+end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -69,23 +69,6 @@ RSpec.describe Request, type: :model do
     end
   end
 
-  describe 'scopes' do
-    let!(:request_created_before_broadcasted_at_introduced) do
-      create(:request, created_at: Time.zone.local(2023, 1, 7, 7, 39), broadcasted_at: nil)
-    end
-    let!(:recent_request) { create(:request) }
-    let!(:planned_request) { create(:request, schedule_send_for: 1.day.from_now, broadcasted_at: nil) }
-
-    context 'broadcasted' do
-      subject { Request.broadcasted }
-      before(:each) { allow(Request).to receive(:broadcast!).and_call_original } # is stubbed for every other test
-
-      it { is_expected.to include(recent_request) }
-      it { is_expected.to include(request_created_before_broadcasted_at_introduced) }
-      it { is_expected.not_to include(planned_request) }
-    end
-  end
-
   it 'has title, text, and user_id' do
     expect(subject.attributes.keys).to include('title', 'text', 'user_id')
   end


### PR DESCRIPTION
The previous solution updating the scope alone to take into account that all requests created before the [schedule requests feature ](https://github.com/tactilenews/100eyes/pull/1581)was released did not take into account ordering the requests by a nil broadcasted_at value. Marking all legacy requests as broadcasted when they were created does.