### PR TITLE
Fix charts logic for empty message array

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -38,9 +38,7 @@ class ChartsController < ApplicationController
   end
 
   def group_messages(messages, group_keys)
-    return [] unless messages.any?
-
-    column = messages.all? { |message| message.is_a? Request } ? :broadcasted_at : :created_at
+    column = messages.any? && messages.all? { |message| message.is_a? Request } ? :broadcasted_at : :created_at
     messages = messages.group_by_day_of_week(column, format: '%A', week_start: :monday) if group_keys.include?(:day_of_week)
     return messages unless group_keys.include?(:hour_of_day)
 

--- a/spec/requests/charts_spec.rb
+++ b/spec/requests/charts_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Charts' do
+  let(:user) { create(:user) }
+  let(:last_friday_midnight) { Time.zone.today.beginning_of_day.prev_occurring(:friday) }
+  let(:request) { create(:request, broadcasted_at: last_friday_midnight) }
+  let(:message) { create(:message, created_at: last_friday_midnight, request: request) }
+  let(:data) do
+    [
+      { x: '00:00', y: 0 },
+      { x: '01:00', y: 0 },
+      { x: '02:00', y: 0 },
+      { x: '03:00', y: 0 },
+      { x: '04:00', y: 0 },
+      { x: '05:00', y: 0 },
+      { x: '06:00', y: 0 },
+      { x: '07:00', y: 0 },
+      { x: '08:00', y: 0 },
+      { x: '09:00', y: 0 },
+      { x: '10:00', y: 0 },
+      { x: '11:00', y: 0 },
+      { x: '12:00', y: 0 },
+      { x: '13:00', y: 0 },
+      { x: '14:00', y: 0 },
+      { x: '15:00', y: 0 },
+      { x: '16:00', y: 0 },
+      { x: '17:00', y: 0 },
+      { x: '18:00', y: 0 },
+      { x: '19:00', y: 0 },
+      { x: '20:00', y: 0 },
+      { x: '21:00', y: 0 },
+      { x: '22:00', y: 0 },
+      { x: '23:00', y: 0 }
+    ].freeze
+  end
+  let(:data_dup) { data.dup.map(&:dup) }
+  let(:friday) { series.find { |hash| hash[:name] == 'Freitag' } }
+  let(:series) do
+    I18n.t('date.day_names').reverse.rotate(-1).map do |day|
+      { name: day, data: data }
+    end
+  end
+
+  describe 'GET /charts/day-and-time-replies' do
+    before do
+      message
+      data_dup.first[:y] = 1
+      friday[:data] = data_dup
+    end
+
+    subject { -> { get charts_day_and_time_replies_path(as: user) } }
+
+    it 'responds with a series of each day and inbound grouped messages' do
+      subject.call
+      expect(response.body).to eq(series.to_json)
+    end
+  end
+
+  describe 'GET /charts/day-and-time-requests' do
+    subject { -> { get charts_day_and_time_requests_path(as: user) } }
+
+    context 'no request, no chat messages' do
+      before { series.map { |hash| hash[:data] = [] } }
+
+      it 'returns empty data array' do
+        subject.call
+        expect(response.body).to eq(series.to_json)
+      end
+    end
+
+    context 'request, no chat messages' do
+      before do
+        request
+        data_dup.first[:y] = 1
+        friday[:data] = data_dup
+      end
+
+      it 'responds with a series of each day and outbound grouped messages' do
+        subject.call
+        expect(response.body).to eq(series.to_json)
+      end
+    end
+
+    context 'request, with chat message' do
+      before do
+        request
+        message.update(broadcasted: false, sender: user, text: 'ChatMessage')
+        data_dup.first[:y] = 2
+        friday[:data] = data_dup
+      end
+
+      it 'responds with a series of each day and outbound grouped messages' do
+        subject.call
+        expect(response.body).to eq(series.to_json)
+      end
+    end
+  end
+
+  describe 'GET /charts/day-requests-replies' do
+    subject { -> { get charts_day_requests_replies_path(as: user) } }
+    let(:data) do
+      I18n.t('date.day_names').rotate(1).map do |day|
+        { x: day, y: 0 }
+      end
+    end
+    let(:series) do
+      [{ name: I18n.t('shared.community'), data: data },
+       { name: I18n.t('shared.editorial'), data: data }]
+    end
+
+    context 'no requests, no replies' do
+      it 'returns empty data array' do
+        subject.call
+        expect(response.body).to eq(series.to_json)
+      end
+    end
+
+    context 'request, no replies' do
+      let(:editorial) { series.find { |hash| hash[:name] == 'Redaktion' } }
+      let(:friday) { data_dup.find { |hash| hash[:x] == 'Freitag' } }
+
+      before do
+        request
+        friday[:y] = 1
+        editorial[:data] = data_dup
+      end
+
+      it 'responds with a series of each day and outbound grouped messages' do
+        subject.call
+        expect(response.body).to eq(series.to_json)
+      end
+    end
+
+    context 'request and replies' do
+      let(:editorial) { series.find { |hash| hash[:name] == 'Redaktion' } }
+      let(:community) { series.find { |hash| hash[:name] == 'Community' } }
+      let(:friday) { data_dup.find { |hash| hash[:x] == 'Freitag' } }
+
+      before do
+        request
+        message
+        friday[:y] = 1
+        editorial[:data] = data_dup
+        community[:data] = data_dup
+      end
+
+      it 'responds with a series of each day and outbound grouped messages' do
+        subject.call
+        expect(response.body).to eq(series.to_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- message.all? returns true if the array is empty and therefore tries to group Message model by broadcasted_at column, which does not exist on Message, but on Request

Fixes #1677 