### PR TITLE
ci: check for unstaged files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,9 @@ jobs:
 
       - name: Run tests
         run: bin/rake spec
+
+      - name: Check unstaged changes
+        run: |
+          git --no-pager diff --color
+          git update-index --refresh
+          git diff-index --quiet HEAD


### PR DESCRIPTION
When you do the following
```
$ asdf install
$ npm --version
6.14.16
```

and run:

```
npm install
```

~then you get a changed `package-lock.json`.~

It is good practice to always check in lock files into version control.
On CI we run `npm install` (among other things). If we make sure that we
do not leave any updates files, this ensures we always commit our lock
files.

EDIT: You don't, my fault. But it does not hurt to merge this PR anyways.
