### PR TITLE
fix(signal-cli-rest-api): native mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   signal:
     image: bbernhard/signal-cli-rest-api:0.67
     environment:
-      - USE_NATIVE=0
+      - MODE=native
         #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)
     ports:
       - "8080:8080" #map docker port 8080 to host port 8080.


### PR DESCRIPTION
 ## Changes

The `USE_NATIVE` flag is deprecated, see: https://github.com/search?q=repo%3Abbernhard%2Fsignal-cli-rest-api%20USE_NATIVE&type=code

As you can see in the search results, the `USE_NATIVE` is ignored. So
I guess, we were using normal mode all the time. In this case the change
will have an effect on the behaviour of `signal-cli-rest-api`.

 ## How to test

1. `docker compose up signal`
2. Deprecation warning is gone
