### PR TITLE
Lock signal-cli to 0.11.11/maintain native mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   signal:
-    image: bbernhard/signal-cli-rest-api:0.119-dev
+    image: tactilenews/signal-cli-rest-api:latest
     environment:
       - MODE=native
         #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)


### PR DESCRIPTION
- upgrading to >= v0.12.0 breaks the implementation while in native mode

Closes #1703 