### PR TITLE
Upgrade signa-cli-rest-api after fix applied upstream

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   signal:
-    image: bbernhard/signal-cli-rest-api:0.119-dev
+    image: bbernhard/signal-cli-rest-api:0.69
     environment:
       - MODE=native
         #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)


### PR DESCRIPTION
- signal-cli >0.12 was broken with native mode