### PR TITLE
refactor: conditional routing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,6 +12,11 @@ THREEMARB_API_IDENTITY=
 THREEMARB_API_SECRET=
 THREEMARB_PRIVATE=
 
+TWILIO_ACCOUNT_SID=
+TWILIO_API_KEY_SID=
+TWILIO_API_KEY_SECRET=
+WHATS_APP_SERVER_PHONE_NUMBER=
+
 # These environment variables are optional during
 # development, but required when running 100eyes
 # in a production environment.

--- a/app/controllers/onboarding/signal_controller.rb
+++ b/app/controllers/onboarding/signal_controller.rb
@@ -3,7 +3,6 @@
 module Onboarding
   class SignalController < OnboardingController
     skip_before_action :verify_jwt, only: :link
-    before_action :ensure_signal_is_set_up
 
     def link; end
 
@@ -19,12 +18,6 @@ module Onboarding
 
     def complete_onboarding(contributor)
       SignalAdapter::CreateContactJob.perform_later(contributor)
-    end
-
-    def ensure_signal_is_set_up
-      return if Setting.signal_server_phone_number.present?
-
-      raise ActionController::RoutingError, 'Not Found'
     end
   end
 end

--- a/app/controllers/onboarding/whats_app_controller.rb
+++ b/app/controllers/onboarding/whats_app_controller.rb
@@ -2,18 +2,10 @@
 
 module Onboarding
   class WhatsAppController < OnboardingController
-    before_action :ensure_whats_app_is_set_up
-
     private
 
     def attr_name
       :whats_app_phone_number
-    end
-
-    def ensure_whats_app_is_set_up
-      return if Setting.whats_app_server_phone_number.present? || Setting.three_sixty_dialog_client_api_key.present?
-
-      raise ActionController::RoutingError, 'Not Found'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,11 @@ Rails.application.routes.draw do
       get '/email', to: 'email#show'
       post '/email', to: 'email#create'
 
-      get '/signal/', to: 'signal#show'
-      get '/signal/link/', to: 'signal#link', as: 'signal_link'
-      post '/signal/', to: 'signal#create'
+      constraints(-> { Setting.signal_server_phone_number.present? }) do
+        get '/signal/', to: 'signal#show'
+        get '/signal/link/', to: 'signal#link', as: 'signal_link'
+        post '/signal/', to: 'signal#create'
+      end
 
       get '/threema/', to: 'threema#show'
       post '/threema/', to: 'threema#create'
@@ -32,8 +34,10 @@ Rails.application.routes.draw do
       get '/telegram/fallback/:telegram_onboarding_token', to: 'telegram#fallback', as: 'telegram_fallback'
       post '/telegram/', to: 'telegram#create'
 
-      get '/whats-app/', to: 'whats_app#show'
-      post '/whats-app/', to: 'whats_app#create'
+      constraints(-> { Setting.whats_app_server_phone_number.present? || Setting.three_sixty_dialog_client_api_key.present? }) do
+        get '/whats-app/', to: 'whats_app#show'
+        post '/whats-app/', to: 'whats_app#create'
+      end
     end
   end
 

--- a/spec/jobs/signal_adapter/receive_polling_job_spec.rb
+++ b/spec/jobs/signal_adapter/receive_polling_job_spec.rb
@@ -45,10 +45,7 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
       before do
         create(:request)
 
-        unless Setting.signal_server_phone_number
-          allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
-        end
-
+        allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
         allow(job).to receive(:ping_monitoring_service).and_return(nil)
       end
 
@@ -174,10 +171,8 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
 
     describe 'given a known contributor requests to unsubscribe', vcr: { cassette_name: :receive_signal_message_to_unsubscribe } do
       before do
-        unless Setting.signal_server_phone_number
-          allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
-          allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
-        end
+        allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
+        allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
       end
 
       let!(:contributor) { create(:contributor, signal_phone_number: '+4915112345789', signal_onboarding_completed_at: Time.zone.now) }
@@ -187,10 +182,8 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
     describe 'given a contributor who has unsubscribed and requests to resubscribe',
              vcr: { cassette_name: :receive_signal_message_to_resubscribe } do
       before do
-        unless Setting.signal_server_phone_number
-          allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
-          allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
-        end
+        allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
+        allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
       end
       let!(:contributor) do
         create(:contributor, signal_phone_number: '+4915112345789', signal_onboarding_completed_at: Time.zone.now,

--- a/spec/requests/onboarding/whatsapp_spec.rb
+++ b/spec/requests/onboarding/whatsapp_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Onboarding::Whatsapp', type: :routing do
+  describe 'GET /onboarding/whatsapp' do
+    subject { { get: '/onboarding/whats-app' } }
+
+    describe 'when no Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('') }
+      it { should_not be_routable }
+    end
+
+    describe 'but when a Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('+49123456789') }
+      it { should be_routable }
+    end
+  end
+
+  describe 'POST /onboarding/whatsapp' do
+    subject { { post: '/onboarding/whats-app' } }
+
+    describe 'when no Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('') }
+      it { should_not be_routable }
+    end
+
+    describe 'but when a Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('+49123456789') }
+      it { should be_routable }
+    end
+  end
+end


### PR DESCRIPTION
refactor: conditional routing

Motivation
----------
It took me a while to debug the 404 error when clicking on the link to:
```
http://localhost:3000/onboarding/whats-app?jwt=eyJhbGc
```

I was expecting to see a problem in `config/routes.rb` but couldn't find anything. It was surprising to me that we programmatically throw a 404 in one of the controllers.

How to test
-----------
1. `bin/rspec ./spec/adapters/signal_adapter/api_spec.rb`
2. Tests pass

Requested changes
-----------------
@mattwr18 asked me to implement this consistently across our codebase. I have seen this only once, here's the commit that introduced it: 9a541d69fd8b41ce269f67eb11dc2fbccf9f5160.
Thankfully there is already a test (that still fails if you remove conditional routing).

In the tests there was:
```
unless Setting.signal_server_phone_number
  allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
  # ..
end
```
from 07694a6fe58e1b7b47abf0e5eda1e90663f0a519.

@mattwr18 this looks intentional, why was that? Did I miss anything?

