### PR TITLE
fix: broken invitation link

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,6 +12,11 @@ THREEMARB_API_IDENTITY=
 THREEMARB_API_SECRET=
 THREEMARB_PRIVATE=
 
+TWILIO_ACCOUNT_SID=
+TWILIO_API_KEY_SID=
+TWILIO_API_KEY_SECRET=
+WHATS_APP_SERVER_PHONE_NUMBER=
+
 # These environment variables are optional during
 # development, but required when running 100eyes
 # in a production environment.

--- a/app/controllers/onboarding/signal_controller.rb
+++ b/app/controllers/onboarding/signal_controller.rb
@@ -3,7 +3,6 @@
 module Onboarding
   class SignalController < OnboardingController
     skip_before_action :verify_jwt, only: :link
-    before_action :ensure_signal_is_set_up
 
     def link; end
 
@@ -19,12 +18,6 @@ module Onboarding
 
     def complete_onboarding(contributor)
       SignalAdapter::CreateContactJob.perform_later(contributor)
-    end
-
-    def ensure_signal_is_set_up
-      return if Setting.signal_server_phone_number.present?
-
-      raise ActionController::RoutingError, 'Not Found'
     end
   end
 end

--- a/app/controllers/onboarding/whats_app_controller.rb
+++ b/app/controllers/onboarding/whats_app_controller.rb
@@ -2,18 +2,10 @@
 
 module Onboarding
   class WhatsAppController < OnboardingController
-    before_action :ensure_whats_app_is_set_up
-
     private
 
     def attr_name
       :whats_app_phone_number
-    end
-
-    def ensure_whats_app_is_set_up
-      return if Setting.whats_app_server_phone_number.present? || Setting.three_sixty_dialog_client_api_key.present?
-
-      raise ActionController::RoutingError, 'Not Found'
     end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -27,6 +27,10 @@ class Setting < RailsSettings::Base
     self.onboarding_hero_blob_id = blob.id
   end
 
+  def self.whats_app_configured?
+    whats_app_server_phone_number.present? || three_sixty_dialog_client_api_key.present?
+  end
+
   field :project_name, default: ENV['HUNDRED_EYES_PROJECT_NAME'] || '100eyes'
   field :application_host, readonly: true, default: ENV['APPLICATION_HOSTNAME'] || 'localhost:3000'
 
@@ -102,6 +106,6 @@ class Setting < RailsSettings::Base
     telegram: true,
     email: true,
     signal: true,
-    whats_app: true
+    whats_app: whats_app_configured?
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,11 @@ Rails.application.routes.draw do
       get '/email', to: 'email#show'
       post '/email', to: 'email#create'
 
-      get '/signal/', to: 'signal#show'
-      get '/signal/link/', to: 'signal#link', as: 'signal_link'
-      post '/signal/', to: 'signal#create'
+      constraints(-> { Setting.signal_server_phone_number.present? }) do
+        get '/signal/', to: 'signal#show'
+        get '/signal/link/', to: 'signal#link', as: 'signal_link'
+        post '/signal/', to: 'signal#create'
+      end
 
       get '/threema/', to: 'threema#show'
       post '/threema/', to: 'threema#create'
@@ -32,8 +34,10 @@ Rails.application.routes.draw do
       get '/telegram/fallback/:telegram_onboarding_token', to: 'telegram#fallback', as: 'telegram_fallback'
       post '/telegram/', to: 'telegram#create'
 
-      get '/whats-app/', to: 'whats_app#show'
-      post '/whats-app/', to: 'whats_app#create'
+      constraints(-> { Setting.whats_app_server_phone_number.present? || Setting.three_sixty_dialog_client_api_key.present? }) do
+        get '/whats-app/', to: 'whats_app#show'
+        post '/whats-app/', to: 'whats_app#create'
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
       get '/telegram/fallback/:telegram_onboarding_token', to: 'telegram#fallback', as: 'telegram_fallback'
       post '/telegram/', to: 'telegram#create'
 
-      constraints(-> { Setting.whats_app_server_phone_number.present? || Setting.three_sixty_dialog_client_api_key.present? }) do
+      constraints(-> { Setting.whats_app_configured? }) do
         get '/whats-app/', to: 'whats_app#show'
         post '/whats-app/', to: 'whats_app#create'
       end

--- a/spec/jobs/signal_adapter/receive_polling_job_spec.rb
+++ b/spec/jobs/signal_adapter/receive_polling_job_spec.rb
@@ -45,10 +45,7 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
       before do
         create(:request)
 
-        unless Setting.signal_server_phone_number
-          allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
-        end
-
+        allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
         allow(job).to receive(:ping_monitoring_service).and_return(nil)
       end
 
@@ -174,10 +171,8 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
 
     describe 'given a known contributor requests to unsubscribe', vcr: { cassette_name: :receive_signal_message_to_unsubscribe } do
       before do
-        unless Setting.signal_server_phone_number
-          allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
-          allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
-        end
+        allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
+        allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
       end
 
       let!(:contributor) { create(:contributor, signal_phone_number: '+4915112345789', signal_onboarding_completed_at: Time.zone.now) }
@@ -187,10 +182,8 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
     describe 'given a contributor who has unsubscribed and requests to resubscribe',
              vcr: { cassette_name: :receive_signal_message_to_resubscribe } do
       before do
-        unless Setting.signal_server_phone_number
-          allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
-          allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
-        end
+        allow(Setting).to receive(:signal_server_phone_number).and_return('SIGNAL_SERVER_PHONE_NUMBER')
+        allow(Setting).to receive(:signal_cli_rest_api_endpoint).and_return('http://signal:8080')
       end
       let!(:contributor) do
         create(:contributor, signal_phone_number: '+4915112345789', signal_onboarding_completed_at: Time.zone.now,

--- a/spec/requests/onboarding/whatsapp_spec.rb
+++ b/spec/requests/onboarding/whatsapp_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Onboarding::Whatsapp', type: :routing do
+  describe 'GET /onboarding/whatsapp' do
+    subject { { get: '/onboarding/whats-app' } }
+
+    describe 'when no Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('') }
+      it { should_not be_routable }
+    end
+
+    describe 'but when a Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('+49123456789') }
+      it { should be_routable }
+    end
+  end
+
+  describe 'POST /onboarding/whatsapp' do
+    subject { { post: '/onboarding/whats-app' } }
+
+    describe 'when no Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('') }
+      it { should_not be_routable }
+    end
+
+    describe 'but when a Whatsapp number was configured' do
+      before { allow(Setting).to receive(:whats_app_server_phone_number).and_return('+49123456789') }
+      it { should be_routable }
+    end
+  end
+end

--- a/spec/system/onboarding/index.spec.rb
+++ b/spec/system/onboarding/index.spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Onboarding' do
+  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
+
+  describe 'visit /onboarding/' do
+    describe 'if WhatsApp was explicitly activated or activated by configuration' do
+      before { allow(Setting).to receive(:channels).and_return({ whats_app: true }) }
+      it 'renders invitation link for WhatsApp' do
+        visit onboarding_path(jwt: jwt)
+        expect(page).to have_css('a', text: 'WhatsApp')
+      end
+    end
+
+    describe 'but if WhatsApp is deactivated' do
+      before { allow(Setting).to receive(:channels).and_return({ whats_app: false }) }
+      it 'renders no invitation link for WhatsApp' do
+        visit onboarding_path(jwt: jwt)
+        expect(page).not_to have_css('a', text: 'WhatsApp')
+      end
+    end
+  end
+end


### PR DESCRIPTION
merge after #1728

Motivation
----------
So this is a follow up for #1728.

It will prevent rendering the whatsapp link unless activated.

We still have an inconsistency, because the channel links depend on
`Setting.channels` whereas the routing depends on
`Setting.whatsapp_configured?`. Ie. `Setting.channels` can be activated
for whatsapp although `Setting.whatsapp_configured?` is false.

How to test
-----------
1. `bin/rspec spec/system/onboarding/index.spec.rb`
2. See:
```
Onboarding
  visit /onboarding/
    if WhatsApp was explicitly activated or activated by configuration
      renders invitation link for WhatsApp
    but if WhatsApp is deactivated
      renders no invitation link for WhatsApp
```

