### PR TITLE
Fix handle delivery receipt where no messages in db

### DIFF
--- a/app/jobs/signal_adapter/receive_polling_job.rb
+++ b/app/jobs/signal_adapter/receive_polling_job.rb
@@ -82,6 +82,8 @@ module SignalAdapter
     def handle_delivery_receipt(delivery_receipt, contributor)
       datetime = Time.zone.at(delivery_receipt[:when] / 1000).to_datetime
       latest_received_message = contributor.received_messages.first
+      return unless latest_received_message
+
       latest_received_message.update(received_at: datetime) if delivery_receipt[:isDelivery]
       latest_received_message.update(read_at: datetime) if delivery_receipt[:isRead]
     end


### PR DESCRIPTION
- When we send out the welcome message, for example, we do not have any messages saved to the db for that contributor, but we still receive a delivery receipt.

Fixes #1734 