### PR TITLE
Handle freeform message not allowed errors programatically

### DIFF
--- a/app/controllers/whats_app/webhook_controller.rb
+++ b/app/controllers/whats_app/webhook_controller.rb
@@ -5,6 +5,8 @@ module WhatsApp
     include WhatsAppHandleCallbacks
 
     skip_before_action :require_login, :verify_authenticity_token
+    before_action :set_contributor, only: :status
+
     UNSUCCESSFUL_DELIVERY = %w[undelivered failed].freeze
     INVALID_MESSAGE_RECIPIENT_ERROR_CODE = 63_024 # https://www.twilio.com/docs/api/errors/63024
     FREEFORM_MESSAGE_NOT_ALLOWED_ERROR_CODE = 63_016 # https://www.twilio.com/docs/api/errors/63016
@@ -62,23 +64,7 @@ module WhatsApp
 
     def status
       head :ok
-      return unless status_params['MessageStatus'].in?(UNSUCCESSFUL_DELIVERY)
-
-      whats_app_phone_number = status_params['To'].split('whatsapp:').last
-      contributor = Contributor.find_by(whats_app_phone_number: whats_app_phone_number)
-      return unless contributor
-
-      if status_params['ErrorCode'].to_i.eql?(INVALID_MESSAGE_RECIPIENT_ERROR_CODE)
-        MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
-        return
-      end
-      if status_params['ErrorCode'].to_i.eql?(FREEFORM_MESSAGE_NOT_ALLOWED_ERROR_CODE) && status_params['MessageStatus'].eql?('failed')
-        handle_freeform_message_not_allowed_error(contributor, status_params['MessageSid'])
-      end
-      exception = WhatsAppAdapter::MessageDeliveryUnsuccessfulError.new(status: status_params['MessageStatus'],
-                                                                        whats_app_phone_number: whats_app_phone_number,
-                                                                        message: status_params['ErrorMessage'])
-      ErrorNotifier.report(exception, context: { message_sid: status_params['MessageSid'] })
+      handle_unsuccessful_delivery if status_params['MessageStatus'].in?(UNSUCCESSFUL_DELIVERY)
     end
 
     private
@@ -97,6 +83,11 @@ module WhatsApp
     def status_params
       params.permit(:AccountSid, :ApiVersion, :ChannelInstallSid, :ChannelPrefix, :ChannelToAddress, :ErrorCode, :ErrorMessage,
                     :EventType, :From, :MessageSid, :MessageStatus, :SmsSid, :SmsStatus, :StructuredMessage, :To)
+    end
+
+    def set_contributor
+      whats_app_phone_number = status_params['To'].split('whatsapp:').last
+      @contributor = Contributor.find_by(whats_app_phone_number: whats_app_phone_number)
     end
 
     def handle_unknown_contributor(whats_app_phone_number)
@@ -135,6 +126,22 @@ module WhatsApp
       return unless message
 
       WhatsAppAdapter::TwilioOutbound.send_message_template!(contributor, message)
+    end
+
+    def handle_unsuccessful_delivery
+      return unless @contributor
+
+      if status_params['ErrorCode'].to_i.eql?(INVALID_MESSAGE_RECIPIENT_ERROR_CODE)
+        MarkInactiveContributorInactiveJob.perform_later(contributor_id: @contributor.id)
+        return
+      end
+      if status_params['ErrorCode'].to_i.eql?(FREEFORM_MESSAGE_NOT_ALLOWED_ERROR_CODE) && status_params['MessageStatus'].eql?('failed')
+        handle_freeform_message_not_allowed_error(@contributor, status_params['MessageSid'])
+      end
+      exception = WhatsAppAdapter::MessageDeliveryUnsuccessfulError.new(status: status_params['MessageStatus'],
+                                                                        whats_app_phone_number: @contributor.whats_app_phone_number,
+                                                                        message: status_params['ErrorMessage'])
+      ErrorNotifier.report(exception, context: { message_sid: status_params['MessageSid'] })
     end
   end
 end

--- a/app/controllers/whats_app/webhook_controller.rb
+++ b/app/controllers/whats_app/webhook_controller.rb
@@ -72,7 +72,7 @@ module WhatsApp
         MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
         return
       end
-      if status_params['ErrorCode'].to_i.eql?(FREEFORM_MESSAGE_NOT_ALLOWED_ERROR_CODE)
+      if status_params['ErrorCode'].to_i.eql?(FREEFORM_MESSAGE_NOT_ALLOWED_ERROR_CODE) && status_params['MessageStatus'].eql?('failed')
         handle_freeform_message_not_allowed_error(contributor, status_params['MessageSid'])
       end
       exception = WhatsAppAdapter::MessageDeliveryUnsuccessfulError.new(status: status_params['MessageStatus'],

--- a/spec/requests/whats_app/webhook_spec.rb
+++ b/spec/requests/whats_app/webhook_spec.rb
@@ -202,8 +202,8 @@ RSpec.describe WhatsApp::WebhookController do
         'ChannelInstallSid' => 'someChannelInstallSid',
         'ChannelPrefix' => 'whatsapp',
         'ChannelToAddress' => whats_app_phone_number.to_s,
-        'ErrorCode' => '63016',
-        'ErrorMessage' => freeform_message_not_allowed_error_message,
+        'ErrorCode' => '60228',
+        'ErrorMessage' => 'Template was not found',
         'From' => "whatsapp:#{Setting.whats_app_server_phone_number}",
         'MessageSid' => 'someSid',
         'MessageStatus' => 'failed',
@@ -213,9 +213,7 @@ RSpec.describe WhatsApp::WebhookController do
         'To' => "whatsapp:#{whats_app_phone_number}"
       }
     end
-    let(:freeform_message_not_allowed_error_message) do
-      'Twilio Error: Failed to send freeform message because you are outside the allowed window.. Generated new message with sid: someSid'
-    end
+
     let(:exception) do
       WhatsAppAdapter::MessageDeliveryUnsuccessfulError.new(status: params['MessageStatus'],
                                                             whats_app_phone_number: whats_app_phone_number, message: params['ErrorMessage'])
@@ -260,6 +258,21 @@ RSpec.describe WhatsApp::WebhookController do
 
       describe 'given a known contributor' do
         let!(:contributor) { create(:contributor, whats_app_phone_number: whats_app_phone_number) }
+        let!(:request) do
+          create(:request, title: 'I failed to send', text: 'Hey {{FIRST_NAME}}, because it was sent outside the allowed window')
+        end
+        let(:valid_account_sid) { 'VALID_ACCOUNT_SID' }
+        let(:valid_api_key_sid) { 'VALID_API_KEY_SID' }
+        let(:valid_api_key_secret) { 'VALID_API_KEY_SECRET' }
+        let(:mock_twilio_rest_client) { instance_double(Twilio::REST::Client) }
+        let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, body: body_text) }
+        let(:body_text) { 'no message with this text saved' }
+
+        before do
+          allow(Twilio::REST::Client).to receive(:new).and_return(mock_twilio_rest_client)
+          allow(mock_twilio_rest_client).to receive(:messages).with('someSid').and_return(messages_double)
+          allow(messages_double).to receive(:fetch).and_return(messages_double)
+        end
 
         describe 'given a failed message delivery' do
           it 'reports the error with the error message' do
@@ -288,21 +301,13 @@ RSpec.describe WhatsApp::WebhookController do
           end
 
           context 'due to a freeform message not allowed error' do
-            let!(:request) do
-              create(:request, title: 'I failed to send', text: 'Hey {{FIRST_NAME}}, because it was sent outside the allowed window')
+            let(:freeform_message_not_allowed_error_message) do
+              'Twilio Error: Failed to send freeform message because you are outside the allowed window.'
             end
-            let(:valid_account_sid) { 'VALID_ACCOUNT_SID' }
-            let(:valid_api_key_sid) { 'VALID_API_KEY_SID' }
-            let(:valid_api_key_secret) { 'VALID_API_KEY_SECRET' }
-            let(:mock_twilio_rest_client) { instance_double(Twilio::REST::Client) }
-            let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, body: body_text) }
-            let(:body_text) { 'no message with this text saved' }
 
             before do
-              subject.call
-              allow(Twilio::REST::Client).to receive(:new).and_return(mock_twilio_rest_client)
-              allow(mock_twilio_rest_client).to receive(:messages).with('someSid').and_return(messages_double)
-              allow(messages_double).to receive(:fetch).and_return(messages_double)
+              params['ErrorCode'] = '63016'
+              params['ErrorMessage'] = freeform_message_not_allowed_error_message
             end
 
             it 'reports it as an error, as we want to track specifics to when this occurs' do
@@ -325,6 +330,13 @@ RSpec.describe WhatsApp::WebhookController do
                   expect(params[:text]).to include(contributor.first_name)
                   expect(params[:text]).to include(message.request.title)
                 end)
+              end
+
+              context 'given an undelivered status' do
+                before { params['MessageStatus'] = 'undelivered' }
+                it 'is expected not to schedule a job as it would send out twice, one for undelivered and one for failed' do
+                  expect { subject.call }.not_to have_enqueued_job(WhatsAppAdapter::Outbound::Text)
+                end
               end
             end
           end

--- a/spec/requests/whats_app/webhook_spec.rb
+++ b/spec/requests/whats_app/webhook_spec.rb
@@ -318,6 +318,7 @@ RSpec.describe WhatsApp::WebhookController do
 
             it 'given message cannot be found by Twilio message sid body' do
               expect { subject.call }.not_to have_enqueued_job(WhatsAppAdapter::Outbound::Text)
+              expect { subject.call }.not_to raise_error
             end
 
             describe 'given a message is found by Twilio message sid body' do

--- a/spec/requests/whats_app/webhook_spec.rb
+++ b/spec/requests/whats_app/webhook_spec.rb
@@ -258,21 +258,6 @@ RSpec.describe WhatsApp::WebhookController do
 
       describe 'given a known contributor' do
         let!(:contributor) { create(:contributor, whats_app_phone_number: whats_app_phone_number) }
-        let!(:request) do
-          create(:request, title: 'I failed to send', text: 'Hey {{FIRST_NAME}}, because it was sent outside the allowed window')
-        end
-        let(:valid_account_sid) { 'VALID_ACCOUNT_SID' }
-        let(:valid_api_key_sid) { 'VALID_API_KEY_SID' }
-        let(:valid_api_key_secret) { 'VALID_API_KEY_SECRET' }
-        let(:mock_twilio_rest_client) { instance_double(Twilio::REST::Client) }
-        let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, body: body_text) }
-        let(:body_text) { 'no message with this text saved' }
-
-        before do
-          allow(Twilio::REST::Client).to receive(:new).and_return(mock_twilio_rest_client)
-          allow(mock_twilio_rest_client).to receive(:messages).with('someSid').and_return(messages_double)
-          allow(messages_double).to receive(:fetch).and_return(messages_double)
-        end
 
         describe 'given a failed message delivery' do
           it 'reports the error with the error message' do
@@ -301,11 +286,23 @@ RSpec.describe WhatsApp::WebhookController do
           end
 
           context 'due to a freeform message not allowed error' do
+            let!(:request) do
+              create(:request, title: 'I failed to send', text: 'Hey {{FIRST_NAME}}, because it was sent outside the allowed window')
+            end
+            let(:valid_account_sid) { 'VALID_ACCOUNT_SID' }
+            let(:valid_api_key_sid) { 'VALID_API_KEY_SID' }
+            let(:valid_api_key_secret) { 'VALID_API_KEY_SECRET' }
+            let(:mock_twilio_rest_client) { instance_double(Twilio::REST::Client) }
+            let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, body: body_text) }
+            let(:body_text) { 'no message with this text saved' }
             let(:freeform_message_not_allowed_error_message) do
               'Twilio Error: Failed to send freeform message because you are outside the allowed window.'
             end
 
             before do
+              allow(Twilio::REST::Client).to receive(:new).and_return(mock_twilio_rest_client)
+              allow(mock_twilio_rest_client).to receive(:messages).with('someSid').and_return(messages_double)
+              allow(messages_double).to receive(:fetch).and_return(messages_double)
               params['ErrorCode'] = '63016'
               params['ErrorMessage'] = freeform_message_not_allowed_error_message
             end


### PR DESCRIPTION
by sending out a message template and tracking the errors

Closes #1739 