### PR TITLE
fix: flaky spec

### DIFF
--- a/spec/system/requests/sending_images_spec.rb
+++ b/spec/system/requests/sending_images_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Sending image files', js: true do
       click_button 'Frage an die Community senden'
       message = page.find('textarea[name="request[text]"]').evaluate_script('this.validationMessage')
       expect(message).to eq 'Please fill out this field.'
-      expect(page).to have_current_path(new_request_path(as: user))
+      expect(page).to have_current_path(new_request_path, ignore_query: true)
 
       # with no text, with file
       visit new_request_path(as: user)
@@ -55,7 +55,7 @@ RSpec.describe 'Sending image files', js: true do
 
       click_button 'Frage an die Community senden'
 
-      expect(page).to have_current_path(new_request_path(as: user))
+      expect(page).to have_current_path(new_request_path, ignore_query: true)
       expect(page).to have_content('Kein gültiges Bildformat. Bitte senden Sie Bilder als jpg, png oder gif.')
 
       # Image file

--- a/spec/system/settings/onboarding_channels_spec.rb
+++ b/spec/system/settings/onboarding_channels_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Configuring Onboarding Channels' do
     end
 
     click_on 'Speichern'
-    expect(page).to have_current_path(settings_path(as: admin))
+    expect(page).to have_current_path(settings_path, ignore_query: true)
 
     within('.OnboardingChannelsCheckboxes') do
       Setting.channels.keys.map(&:to_sym).each do |key|


### PR DESCRIPTION
 Motivation
 ----------
 Also this took me way too long to fix. #1729 suffers under some unrelated failing spec. On my machine, even when I `git switch main` on the 07694a6fe58e1b7b47abf0e5eda1e90663f0a519 I will see sometimes a failing spec, sometimes it passes.

Here is an example:
```

  1) Configuring Onboarding Channels allows activating and deactivating onboarding channels
     Failure/Error: expect(page).to have_current_path(settings_path(as: admin))
       expected "/settings" to equal "/settings?as=177"

     [Screenshot Image]: tmp/screenshots/failures_r_spec_example_groups_configuring_onboarding_channels_allows_activating_and_deactivating_onboarding_channels_617.png

     # ./spec/system/settings/onboarding_channels_spec.rb:26:in `block (2 levels) in <main>'
     # ./spec/support/better_rails_system_tests.rb:26:in `block (2 levels) in <main>'
     # -e:1:in `<main>'
```

I don't think it is necessary to check the query params here, maybe it was even an oversight. What I still don't understand: What is `some_route_path(as: some_user)` even doing? And why did it work in the past?

 How to test
 -----------
 1. `git switch main`
 2. `bin/rspec spec/system/settings/onboarding_channels_spec.rb` multiple (!) times
 3. Sometims green, sometimes red

 This should not happen on this branch anymore.