### PR TITLE
Twilio WhatsApp use delivery receipts to mark message as received/read

### DIFF
--- a/app/adapters/whats_app_adapter/outbound/file.rb
+++ b/app/adapters/whats_app_adapter/outbound/file.rb
@@ -9,16 +9,20 @@ module WhatsAppAdapter
         @twilio_instance = Twilio::REST::Client.new(Setting.twilio_api_key_sid, Setting.twilio_api_key_secret, Setting.twilio_account_sid)
       end
 
-      def perform(contributor_id:, text:, file:)
+      def perform(contributor_id:, message:)
         contributor = Contributor.find(contributor_id)
         return unless contributor
 
-        self.class.twilio_instance.messages.create(
-          from: "whatsapp:#{Setting.whats_app_server_phone_number}",
-          body: text,
-          to: "whatsapp:#{contributor.whats_app_phone_number}",
-          media_url: Rails.application.routes.url_helpers.rails_blob_url(file.attachment.blob, host: Setting.application_host)
-        )
+        responses = message.files.each_with_index.map do |file, index|
+          self.class.twilio_instance.messages.create(
+            from: "whatsapp:#{Setting.whats_app_server_phone_number}",
+            body: index.zero? ? message.text : '',
+            to: "whatsapp:#{contributor.whats_app_phone_number}",
+            media_url: Rails.application.routes.url_helpers.rails_blob_url(file.attachment.blob, host: Setting.application_host)
+          )
+        end
+
+        message.update(external_id: responses.first.sid)
       end
     end
   end

--- a/app/adapters/whats_app_adapter/outbound/text.rb
+++ b/app/adapters/whats_app_adapter/outbound/text.rb
@@ -9,15 +9,18 @@ module WhatsAppAdapter
         @twilio_instance = Twilio::REST::Client.new(Setting.twilio_api_key_sid, Setting.twilio_api_key_secret, Setting.twilio_account_sid)
       end
 
-      def perform(contributor_id:, text:)
+      def perform(contributor_id:, text:, message: nil)
         contributor = Contributor.find(contributor_id)
         return unless contributor
 
-        self.class.twilio_instance.messages.create(
+        response = self.class.twilio_instance.messages.create(
           from: "whatsapp:#{Setting.whats_app_server_phone_number}",
           body: text,
           to: "whatsapp:#{contributor.whats_app_phone_number}"
         )
+        return unless message
+
+        message.update(external_id: response.sid)
       end
     end
   end

--- a/app/adapters/whats_app_adapter/twilio_outbound.rb
+++ b/app/adapters/whats_app_adapter/twilio_outbound.rb
@@ -94,11 +94,9 @@ module WhatsAppAdapter
         files = message.files
 
         if files.blank?
-          WhatsAppAdapter::Outbound::Text.perform_later(contributor_id: recipient.id, text: message.text)
+          WhatsAppAdapter::Outbound::Text.perform_later(contributor_id: recipient.id, text: message.text, message: message)
         else
-          files.each_with_index do |file, index|
-            WhatsAppAdapter::Outbound::File.perform_later(contributor_id: recipient.id, text: index.zero? ? message.text : '', file: file)
-          end
+          WhatsAppAdapter::Outbound::File.perform_later(contributor_id: recipient.id, message: message)
         end
       end
     end

--- a/spec/adapters/whats_app_adapter/outbound/file_spec.rb
+++ b/spec/adapters/whats_app_adapter/outbound/file_spec.rb
@@ -9,20 +9,35 @@ RSpec.describe WhatsAppAdapter::Outbound::File do
   let(:valid_api_key_sid) { 'VALID_API_KEY_SID' }
   let(:valid_api_key_secret) { 'VALID_API_KEY_SECRET' }
   let(:mock_twilio_rest_client) { instance_double(Twilio::REST::Client) }
-  let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance) }
+  let(:message_list_double) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList) }
+  let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, sid: twilio_message_sid_from_first_file) }
+  let(:subsequent_messages_double) do
+    double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, sid: 'subsequent_valid_twilio_message_sid')
+  end
   let(:contributor) do
     create(:contributor, whats_app_phone_number: whats_app_phone_number, email: nil)
   end
-  let(:message) { create(:message, recipient: contributor, files: [create(:file)]) }
+  let(:message) { create(:message, recipient: contributor, files: [create(:file), create(:file)]) }
   let(:expected_params) do
-    { from: "whatsapp:#{Setting.whats_app_server_phone_number}",
+    {
+      from: "whatsapp:#{Setting.whats_app_server_phone_number}",
       body: message.text,
       to: "whatsapp:#{contributor.whats_app_phone_number}",
-      media_url: Rails.application.routes.url_helpers.rails_blob_url(message.files.first.attachment.blob, host: Setting.application_host) }
+      media_url: Rails.application.routes.url_helpers.rails_blob_url(message.files.first.attachment.blob, host: Setting.application_host)
+    }
   end
+  let(:subsequent_expected_params) do
+    {
+      from: "whatsapp:#{Setting.whats_app_server_phone_number}",
+      body: '',
+      to: "whatsapp:#{contributor.whats_app_phone_number}",
+      media_url: Rails.application.routes.url_helpers.rails_blob_url(message.files.second.attachment.blob, host: Setting.application_host)
+    }
+  end
+  let(:twilio_message_sid_from_first_file) { 'valid_twilio_message_sid' }
 
   describe '#perform' do
-    subject { -> { adapter.perform(contributor_id: message.recipient.id, text: message.text, file: message.files.first) } }
+    subject { -> { adapter.perform(contributor_id: message.recipient.id, message: message) } }
 
     before do
       allow(Setting).to receive(:twilio_account_sid).and_return(valid_account_sid)
@@ -30,14 +45,19 @@ RSpec.describe WhatsAppAdapter::Outbound::File do
       allow(Setting).to receive(:twilio_api_key_secret).and_return(valid_api_key_secret)
       allow(Twilio::REST::Client).to receive(:new).with(valid_api_key_sid, valid_api_key_secret,
                                                         valid_account_sid).and_return(mock_twilio_rest_client)
-      allow(mock_twilio_rest_client).to receive(:messages).and_return(messages_double)
-      allow(messages_double).to receive(:create)
+      allow(mock_twilio_rest_client).to receive(:messages).and_return(message_list_double)
+      allow(message_list_double).to receive(:create).and_return(messages_double, subsequent_messages_double)
     end
 
     it 'creates the message' do
-      expect(messages_double).to receive(:create).with(expected_params)
+      expect(message_list_double).to receive(:create).with(expected_params)
+      expect(message_list_double).to receive(:create).with(subsequent_expected_params)
 
       subject.call
+    end
+
+    it 'saves the external id' do
+      expect { subject.call }.to change { message.reload.external_id }.from(nil).to(twilio_message_sid_from_first_file)
     end
   end
 end

--- a/spec/adapters/whats_app_adapter/outbound/text_spec.rb
+++ b/spec/adapters/whats_app_adapter/outbound/text_spec.rb
@@ -9,32 +9,55 @@ RSpec.describe WhatsAppAdapter::Outbound::Text do
   let(:valid_api_key_sid) { 'VALID_API_KEY_SID' }
   let(:valid_api_key_secret) { 'VALID_API_KEY_SECRET' }
   let(:mock_twilio_rest_client) { instance_double(Twilio::REST::Client) }
-  let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance) }
+  let(:message_list_double) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList) }
+  let(:messages_double) { double(Twilio::REST::Api::V2010::AccountContext::MessageInstance, sid: twilio_message_sid) }
   let(:contributor) do
     create(:contributor, whats_app_phone_number: whats_app_phone_number, email: nil)
   end
   let(:message) { create(:message, recipient: contributor) }
   let(:expected_params) do
-    { from: "whatsapp:#{Setting.whats_app_server_phone_number}", body: message.text, to: "whatsapp:#{contributor.whats_app_phone_number}" }
+    { from: "whatsapp:#{Setting.whats_app_server_phone_number}", body: text, to: "whatsapp:#{contributor.whats_app_phone_number}" }
   end
+  let(:twilio_message_sid) { 'valid_twilio_message_sid' }
 
   describe '#perform' do
-    subject { -> { adapter.perform(contributor_id: message.recipient.id, text: message.text) } }
-
     before do
       allow(Setting).to receive(:twilio_account_sid).and_return(valid_account_sid)
       allow(Setting).to receive(:twilio_api_key_sid).and_return(valid_api_key_sid)
       allow(Setting).to receive(:twilio_api_key_secret).and_return(valid_api_key_secret)
       allow(Twilio::REST::Client).to receive(:new).with(valid_api_key_sid, valid_api_key_secret,
                                                         valid_account_sid).and_return(mock_twilio_rest_client)
-      allow(mock_twilio_rest_client).to receive(:messages).and_return(messages_double)
+      allow(mock_twilio_rest_client).to receive(:messages).and_return(message_list_double)
+      allow(message_list_double).to receive(:create).and_return(messages_double)
       allow(messages_double).to receive(:create)
     end
 
-    it 'creates the message' do
-      expect(messages_double).to receive(:create).with(expected_params)
+    context 'given simply text' do
+      subject { -> { adapter.perform(contributor_id: message.recipient.id, text: text) } }
 
-      subject.call
+      let(:text) { 'Welcome to 100eyes' }
+
+      it 'creates the message' do
+        expect(message_list_double).to receive(:create).with(expected_params)
+
+        subject.call
+      end
+    end
+
+    context 'given a Message instance' do
+      subject { -> { adapter.perform(contributor_id: message.recipient.id, text: text, message: message) } }
+
+      let(:text) { message.text }
+
+      it 'creates the message' do
+        expect(message_list_double).to receive(:create).with(expected_params)
+
+        subject.call
+      end
+
+      it 'saves the external id' do
+        expect { subject.call }.to change { message.reload.external_id }.from(nil).to(twilio_message_sid)
+      end
     end
   end
 end

--- a/spec/adapters/whats_app_adapter/twilio_outbound_spec.rb
+++ b/spec/adapters/whats_app_adapter/twilio_outbound_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe WhatsAppAdapter::TwilioOutbound do
           expect { subject.call }.to(have_enqueued_job(WhatsAppAdapter::Outbound::Text).on_queue('default').with do |params|
             expect(params[:contributor_id]).to eq(contributor.id)
             expect(params[:text]).to eq(message.text)
+            expect(params[:message]).to eq(message)
           end)
         end
       end
@@ -75,6 +76,7 @@ RSpec.describe WhatsAppAdapter::TwilioOutbound do
           expect { subject.call }.to(have_enqueued_job(WhatsAppAdapter::Outbound::Text).on_queue('default').with do |params|
             expect(params[:contributor_id]).to eq(contributor.id)
             expect(params[:text]).to eq(message.text)
+            expect(params[:message]).to eq(message)
           end)
         end
       end
@@ -97,9 +99,8 @@ RSpec.describe WhatsAppAdapter::TwilioOutbound do
           before { create(:message, sender: contributor) }
           it 'enqueues a File job with file, contributor, text' do
             expect { subject.call }.to(have_enqueued_job(WhatsAppAdapter::Outbound::File).on_queue('default').with do |params|
-              expect(params[:file]).to eq(message.files.first)
+              expect(params[:message]).to eq(message)
               expect(params[:contributor_id]).to eq(contributor.id)
-              expect(params[:text]).to eq(message.text)
             end)
           end
         end


### PR DESCRIPTION
Closes #1746 