### PR TITLE
Improve UX by adding request files to request form

### DIFF
--- a/app/components/request_form/request_form.html.erb
+++ b/app/components/request_form/request_form.html.erb
@@ -60,6 +60,34 @@
               class="RequestForm-filenamesList"
             ></ul>
           </div>
+          <% if @request.files.attached? %>
+            <div class="RequestForm-filenamesWrapper">
+              <%= c 'heading', style: :gamma do %>
+                <%= t('.attached_images') %>
+              <% end %>
+              <ul
+                data-request-form-target="filenames"
+                class="RequestForm-filenamesList"
+              >
+              <% @request.files.each_with_index do |file, index| %>
+                <li
+                  id="image-filename-<%= file.blob[:filename] %>"
+                  class="RequestForm-filenamesListItem"
+                >
+                  <p class="RequestForm-filename"><%= file.blob[:filename] %></p>
+                  <button
+                    class="RequestForm-removeListItemButton Button"
+                    data-action="request-form#removeImageFromRequest"
+                    data-request-form-image-index-value="<%= index %>"
+                    type="button"
+                  >
+                   x
+                  </button>
+                </li>
+              <% end %>
+              </ul>
+            </div>
+          <% end %>
         <% end %>
 
         <%= c 'field', object: @request, attr: :schedule_send_for do  |field| %>

--- a/app/components/request_form/request_form.html.erb
+++ b/app/components/request_form/request_form.html.erb
@@ -61,15 +61,12 @@
               class="RequestForm-filenamesList"
             ></ul>
           </div>
-          <% if @request.files.attached? %>
+          <% if @request.planned? && @request.files.attached? %>
             <div class="RequestForm-filenamesWrapper">
               <%= c 'heading', style: :gamma do %>
                 <%= t('.attached_images') %>
               <% end %>
-              <ul
-                data-request-form-target="filenames"
-                class="RequestForm-filenamesList"
-              >
+              <ul class="RequestForm-filenamesList">
               <% @request.files.each_with_index do |file, index| %>
                 <li
                   id="image-filename-<%= file.blob[:filename] %>"

--- a/app/components/request_form/request_form.html.erb
+++ b/app/components/request_form/request_form.html.erb
@@ -3,6 +3,7 @@
   data-controller="request-form"
   data-request-form-members-count-message-value="<%= t('components.request_form.members_count_message').to_json %>"
   data-request-form-preview-fallback-value="<%= t('components.request_form.preview_fallback') %>"
+  data-request-form-request-files-url-value="<%= @request.files.map { |file| url_for(file) } %>"
 >
 
   <div class="RequestForm-column" data-action="input->request-form#updatePreview">

--- a/app/components/request_form/request_form.html.erb
+++ b/app/components/request_form/request_form.html.erb
@@ -31,23 +31,22 @@
               <% if @request.planned? && @request.files.attached? %>
                 <% @request.files.each do |file| %>
                   <%= field.hidden_field(:request,
-                                       :files,
-                                        data: { request_form_target: 'imageInputAttachedFile' },
-                                        multiple: true,
-                                        value: file.signed_id
+                                         :files,
+                                         data: { request_form_target: 'imageInputAttachedFile' },
+                                         multiple: true,
+                                         value: file.signed_id
 
                   ) %>
                 <% end %>
-              <% else %>
-                <%= field.file_field(:request,
-                                    :files,
-                                    data: { request_form_target: 'imageInput' },
-                                    multiple: true,
-                                    hidden: true,
-                                    accept: 'image/*'
-
-                ) %>
               <% end %>
+              <%= field.file_field(:request,
+                                   :files,
+                                   data: { request_form_target: 'imageInput' },
+                                   multiple: true,
+                                   hidden: true,
+                                   accept: 'image/*'
+
+              ) %>
               <%= t('.attach_image_to_message') %>
             <% end %>
           <% end %>
@@ -72,17 +71,8 @@
             <ul
               data-request-form-target="filenames"
               class="RequestForm-filenamesList"
-            ></ul>
-          </div>
-          <% if @request.planned? && @request.files.attached? %>
-            <div class="RequestForm-filenamesWrapper">
-              <%= c 'heading', style: :gamma do %>
-                <%= t('.attached_images') %>
-              <% end %>
-              <ul
-                class="RequestForm-filenamesList"
-                data-request-form-target="attachedFiles"
-              >
+            >
+            <% if @request.planned? && @request.files.attached? %>
               <% @request.files.each do |file| %>
                 <li
                   id="image-filename-<%= file.blob[:filename] %>"
@@ -100,9 +90,9 @@
                   </button>
                 </li>
               <% end %>
-              </ul>
-            </div>
-          <% end %>
+            <% end %>
+            </ul>
+          </div>
         <% end %>
 
         <%= c 'field', object: @request, attr: :schedule_send_for do  |field| %>

--- a/app/components/request_form/request_form.html.erb
+++ b/app/components/request_form/request_form.html.erb
@@ -28,13 +28,26 @@
               class: 'RequestForm-insertPlaceholderButton',
               type: 'button',
               data: { action: 'request-form#insertImage' } do %>
-              <%= field.file_field(:request,
-                                   :files,
-                                   data: { request_form_target: 'imageInput' },
-                                   multiple: true,
-                                   accept: 'image/*'
+              <% if @request.planned? && @request.files.attached? %>
+                <% @request.files.each do |file| %>
+                  <%= field.hidden_field(:request,
+                                       :files,
+                                        data: { request_form_target: 'imageInputAttachedFile' },
+                                        multiple: true,
+                                        value: file.signed_id
 
-              ) %>
+                  ) %>
+                <% end %>
+              <% else %>
+                <%= field.file_field(:request,
+                                    :files,
+                                    data: { request_form_target: 'imageInput' },
+                                    multiple: true,
+                                    hidden: true,
+                                    accept: 'image/*'
+
+                ) %>
+              <% end %>
               <%= t('.attach_image_to_message') %>
             <% end %>
           <% end %>
@@ -66,8 +79,11 @@
               <%= c 'heading', style: :gamma do %>
                 <%= t('.attached_images') %>
               <% end %>
-              <ul class="RequestForm-filenamesList">
-              <% @request.files.each_with_index do |file, index| %>
+              <ul
+                class="RequestForm-filenamesList"
+                data-request-form-target="attachedFiles"
+              >
+              <% @request.files.each do |file| %>
                 <li
                   id="image-filename-<%= file.blob[:filename] %>"
                   class="RequestForm-filenamesListItem"
@@ -75,8 +91,9 @@
                   <p class="RequestForm-filename"><%= file.blob[:filename] %></p>
                   <button
                     class="RequestForm-removeListItemButton Button"
-                    data-action="request-form#removeImageFromRequest"
-                    data-request-form-image-index-value="<%= index %>"
+                    data-action="request-form#removeAttachedImage"
+                    data-request-form-image-id-value="<%= file.signed_id %>"
+                    data-request-form-image-url-value="<%= url_for(file) %>"
                     type="button"
                   >
                    x

--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -107,6 +107,10 @@ export default class extends Controller {
       div.classList.add('RequestForm-imagePreviewWrapper');
       div.setAttribute('id', 'image-preview-wrapper');
     }
+
+    figure.appendChild(div);
+    this.previewTarget.parentNode.appendChild(figure);
+
     return [figure, div];
   }
 
@@ -139,7 +143,7 @@ export default class extends Controller {
       this.setImageAttributes(img, URL.createObjectURL(file));
     }
 
-    this.addPreview(figure, div, message);
+    this.addPreview(figure, message);
   }
 
   addAttachedRequestFilesPreview(urls, message) {
@@ -159,19 +163,21 @@ export default class extends Controller {
       }
     });
 
-    this.addPreview(figure, div, message);
+    this.addPreview(figure, message);
   }
 
-  addPreview(figure, div, message) {
-    figure.appendChild(div);
-    const figcaption = document.createElement('figcaption');
-    figcaption.setAttribute('id', 'caption');
-    figure.setAttribute('id', 'file-preview');
-    figure.appendChild(figcaption);
+  addPreview(figure, message) {
+    let figcaption = document.getElementById('caption');
 
-    this.previewTarget.parentNode.appendChild(figure);
-    const firstFigcaption = figure.querySelector('figcaption');
-    firstFigcaption.innerHTML = message;
+    if (!figcaption) {
+      figcaption = document.createElement('figcaption');
+      figcaption.setAttribute('id', 'caption');
+      figure.setAttribute('id', 'file-preview');
+      figure.appendChild(figcaption);
+    }
+
+    figure.appendChild(figcaption);
+    figcaption.innerHTML = message;
   }
 
   removeExistingImagePreview() {

--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -14,6 +14,8 @@ export default class extends Controller {
     'submitButton',
     'characterCounter',
     'modal',
+    'attachedFiles',
+    'imageInputAttachedFile',
   ];
   static values = {
     membersCountMessage: String,
@@ -24,7 +26,6 @@ export default class extends Controller {
   connect() {
     this.updatePreview();
     this.updateMembersCount();
-    this.imageInputTarget.classList.add('hidden');
     this.updateCharacterCounter();
   }
 
@@ -89,7 +90,9 @@ export default class extends Controller {
   }
 
   insertImage() {
-    this.imageInputTarget.click();
+    if (this.hasImageInputTarget) this.imageInputTarget.click();
+    if (this.hasImageInputAttachedFileTarget)
+      this.imageInputAttachedFileTarget.click();
   }
 
   addImagePreview(files, message) {
@@ -208,6 +211,33 @@ export default class extends Controller {
       this.messageTarget.setAttribute('required', true);
     } else {
       this.addImagePreview(this.imageInputTarget.files, this.setCaption());
+    }
+  }
+
+  removeAttachedImage(event) {
+    event.target.parentNode.remove();
+
+    const id = event.target.dataset.requestFormImageIdValue;
+    const url = event.target.dataset.requestFormImageUrlValue;
+    this.requestFilesUrlValue = this.requestFilesUrlValue.filter(u => u == url);
+    const hiddenInputs = this.imageInputAttachedFileTargets;
+    const inputToDelete = hiddenInputs.find(
+      image => image.getAttribute('value') == id
+    );
+    inputToDelete.remove();
+    if (this.imageInputAttachedFileTargets.length == 0) {
+      this.removeExistingImagePreview();
+      this.removeExistingFilesname();
+      this.attachedFilesTarget.parentNode.classList.add(
+        'RequestForm-filenamesWrapper--hidden'
+      );
+      this.previewTarget.innerHTML = this.setMessage();
+      this.messageTarget.setAttribute('required', true);
+    } else {
+      this.addAttachedRequestFilesPreview(
+        this.requestFilesUrlValue,
+        this.setCaption()
+      );
     }
   }
 

--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -96,7 +96,7 @@ export default class extends Controller {
     this.imageInputTarget.click();
   }
 
-  addImagePreview(files, message) {
+  setUpImagePreview() {
     let figure = document.getElementById('file-preview');
     let div;
     if (figure) {
@@ -106,6 +106,11 @@ export default class extends Controller {
       div = document.createElement('div');
       div.classList.add('RequestForm-imagePreviewWrapper');
     }
+    return [figure, div];
+  }
+
+  addImagePreview(files, message) {
+    const [figure, div] = this.setUpImagePreview();
 
     for (let i = 0; i < files.length; i++) {
       let file = files.item(i);
@@ -137,15 +142,7 @@ export default class extends Controller {
   }
 
   addAttachedRequestFilesPreview(urls, message) {
-    let figure = document.getElementById('file-preview');
-    let div;
-    if (figure) {
-      div = figure.firstChild;
-    } else {
-      figure = document.createElement('figure');
-      div = document.createElement('div');
-      div.classList.add('RequestForm-imagePreviewWrapper');
-    }
+    const [figure, div] = this.setUpImagePreview();
 
     urls.forEach((url, i) => {
       const img = document.createElement('img');

--- a/app/components/request_form/request_form.js
+++ b/app/components/request_form/request_form.js
@@ -100,11 +100,12 @@ export default class extends Controller {
     let figure = document.getElementById('file-preview');
     let div;
     if (figure) {
-      div = figure.firstChild;
+      div = document.getElementById('image-preview-wrapper');
     } else {
       figure = document.createElement('figure');
       div = document.createElement('div');
       div.classList.add('RequestForm-imagePreviewWrapper');
+      div.setAttribute('id', 'image-preview-wrapper');
     }
     return [figure, div];
   }
@@ -145,13 +146,17 @@ export default class extends Controller {
     const [figure, div] = this.setUpImagePreview();
 
     urls.forEach((url, i) => {
-      const img = document.createElement('img');
-      img.classList.add('RequestForm-imagePreview');
-      if (urls.length % 2 == 1 && i == 0) {
-        img.classList.add('RequestForm-firstImageInOddNumber');
+      const existingImage = document.getElementById(`image-${url}`);
+      if (!existingImage) {
+        const img = document.createElement('img');
+        img.setAttribute('id', `image-${url}`);
+        img.classList.add('RequestForm-imagePreview');
+        if (urls.length % 2 == 1 && i == 0) {
+          img.classList.add('RequestForm-firstImageInOddNumber');
+        }
+        div.appendChild(img);
+        this.setImageAttributes(img, url);
       }
-      div.appendChild(img);
-      this.setImageAttributes(img, url);
     });
 
     this.addPreview(figure, div, message);
@@ -208,23 +213,7 @@ export default class extends Controller {
     this.imageInputTarget.files = dt.files;
     event.target.parentNode.remove();
     this.removeExistingImagePreview();
-
-    if (
-      this.imageInputTarget.files.length == 0 &&
-      this.imageInputAttachedFileTargets.length == 0
-    ) {
-      this.filenamesTarget.parentNode.classList.add(
-        'RequestForm-filenamesWrapper--hidden'
-      );
-      this.previewTarget.innerHTML = this.setMessage();
-      this.messageTarget.setAttribute('required', true);
-    } else {
-      this.addImagePreview(this.imageInputTarget.files, this.setCaption());
-      this.addAttachedRequestFilesPreview(
-        this.requestFilesUrlValue,
-        this.setCaption()
-      );
-    }
+    this.updatePreviewAfterRemoveEvent();
   }
 
   removeAttachedImage(event) {
@@ -239,10 +228,13 @@ export default class extends Controller {
     );
     inputToDelete.remove();
     this.removeExistingImagePreview();
+    this.updatePreviewAfterRemoveEvent();
+  }
 
+  updatePreviewAfterRemoveEvent() {
     if (
-      this.imageInputAttachedFileTargets.length == 0 &&
-      this.imageInputTarget.files.length == 0
+      this.imageInputTarget.files.length == 0 &&
+      this.imageInputAttachedFileTargets.length == 0
     ) {
       this.filenamesTarget.parentNode.classList.add(
         'RequestForm-filenamesWrapper--hidden'

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -43,6 +43,7 @@ class RequestsController < ApplicationController
   def edit; end
 
   def update
+    @request.files.purge_later if @request.files.attached? && request_params[:files].blank?
     if @request.update(request_params)
       if @request.planned?
         redirect_to requests_path(filter: :planned), flash: {

--- a/spec/system/requests/sending_images_spec.rb
+++ b/spec/system/requests/sending_images_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Sending image files', js: true do
       expect(message).to eq 'Please fill out this field.'
       expect(page).to have_current_path(new_request_path(as: user))
 
-      # with no text, with file
+      # With no text, with file
       visit new_request_path(as: user)
 
       fill_in 'Titel', with: 'Message with files, no text'
@@ -37,6 +37,7 @@ RSpec.describe 'Sending image files', js: true do
       find_field('request_files', visible: :all).attach_file(image_file)
 
       click_button 'Frage an die Community senden'
+
       expect(page).to have_content('Message with files, no text')
       expect(page).to have_current_path(request_path(Request.first))
 
@@ -73,7 +74,6 @@ RSpec.describe 'Sending image files', js: true do
       expect(page).to have_css(
         'button.RequestForm-removeListItemButton[data-action="request-form#removeImage"][data-request-form-image-index-value="0"]'
       )
-
       click_button 'x'
 
       expect(page).not_to have_content('Angehängte Bilder')


### PR DESCRIPTION
When a planned request that has files attached is being edited, you cannot see what files are attached or remove any. This PR gives the api to remove them from the request before sending out.

Closes #1755