### PR TITLE
Fix faulty file type determination logic

### DIFF
--- a/app/components/chat_message/chat_message.html.erb
+++ b/app/components/chat_message/chat_message.html.erb
@@ -59,34 +59,36 @@
       <% end %>
     <% end %>
 
-    <% if image? %>
-      <% if message.text.blank? %>
+    <% unless files.empty? %>
+      <% if image? %>
+        <% if message.text.blank? %>
+          <header class="ChatMessage-header">
+            <% if message.sender %>
+              <%= c 'avatar', record: message.sender, style: :small, class: "ChatMessage-avatar" %>
+            <% else %>
+              <%= c 'avatar', style: :small, class: "ChatMessage-avatar" %>
+            <% end %>
+            <%= c 'chat_message_photos', photos: image_files %>
+          </header>
+        <% else %>
+          <%= c 'chat_message_photos', photos: image_files %>
+        <% end %>
+      <% end %>
+
+      <% if audio? %>
         <header class="ChatMessage-header">
           <% if message.sender %>
             <%= c 'avatar', record: message.sender, style: :small, class: "ChatMessage-avatar" %>
           <% else %>
             <%= c 'avatar', style: :small, class: "ChatMessage-avatar" %>
           <% end %>
-          <%= c 'chat_message_photos', photos: files %>
+          <%= c 'chat_message_audio', audios: audio_files %>
         </header>
-      <% else %>
-        <%= c 'chat_message_photos', photos: files %>
       <% end %>
-    <% end %>
 
-    <% if audio? %>
-      <header class="ChatMessage-header">
-        <% if message.sender %>
-          <%= c 'avatar', record: message.sender, style: :small, class: "ChatMessage-avatar" %>
-        <% else %>
-          <%= c 'avatar', style: :small, class: "ChatMessage-avatar" %>
-        <% end %>
-        <%= c 'chat_message_audio', audio: audio %>
-      </header>
-    <% end %>
-
-    <% if video? %>
-      <%= c 'chat_message_video', videos: files %>
+      <% if video? %>
+        <%= c 'chat_message_video', videos: video_files %>
+      <% end %>
     <% end %>
 
     <footer class="ChatMessage-footer">

--- a/app/components/chat_message/chat_message.rb
+++ b/app/components/chat_message/chat_message.rb
@@ -24,27 +24,35 @@ module ChatMessage
     end
 
     def audio?
-      files.first.attachment.blob.audio? unless files.empty?
+      files.any? { |file| file.attachment.blob.content_type.match? /audio/ }
     end
 
     def image?
-      files.first.attachment.blob.image? unless files.empty?
+      files.any? { |file| file.attachment.blob.content_type.match? /image/ }
     end
 
     def video?
-      files.first.attachment.blob.video? unless files.empty?
+      files.any? { |file| file.attachment.blob.content_type.match? /video/ }
     end
 
     def photos
       message.photos
     end
 
+    def image_files
+      files.select { |file| file.attachment.blob.content_type.match? /image/ }
+    end
+
+    def video_files
+      files.select { |file| file.attachment.blob.content_type.match? /video/ }
+    end
+
     def files
       message.files
     end
 
-    def audio
-      files.first unless files.empty?
+    def audio_files
+      files.select { |file| file.attachment.blob.content_type.match? /audio/ }
     end
 
     def creator_name

--- a/app/components/chat_message_audio/chat_message_audio.html.erb
+++ b/app/components/chat_message_audio/chat_message_audio.html.erb
@@ -1,6 +1,8 @@
 <div class="ChatMessageAudio">
-  <audio controls>
-    <source src="<%= url_for(audio.attachment) %>" type="audio/ogg">
-    <%= t 'components.chat_message_audio.no_audio_support' %>
-  </audio>
+  <% audios.each do |audio| %>
+    <audio controls>
+      <source src="<%= url_for(audio.attachment) %>" type="audio/ogg">
+      <%= t 'components.chat_message_audio.no_audio_support' %>
+    </audio>
+  <% end %>
 </div>

--- a/app/components/chat_message_audio/chat_message_audio.rb
+++ b/app/components/chat_message_audio/chat_message_audio.rb
@@ -2,14 +2,14 @@
 
 module ChatMessageAudio
   class ChatMessageAudio < ApplicationComponent
-    def initialize(audio:, **)
+    def initialize(audios:, **)
       super
 
-      @audio = audio
+      @audios = audios
     end
 
     private
 
-    attr_reader :audio
+    attr_reader :audios
   end
 end

--- a/spec/components/chat_message_voice_spec.rb
+++ b/spec/components/chat_message_voice_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ChatMessageAudio::ChatMessageAudio, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
-  let(:audio) { create(:file) }
-  let(:params) { { audio: audio } }
+  let(:audios) { [create(:file)] }
+  let(:params) { { audios: audios } }
   it { should have_css('.ChatMessageAudio') }
 end


### PR DESCRIPTION
- Previously we assumed that all files attached to a message were the same mime/content type. For some messengers, grouped files are received as one message and can have different mime/content types. We now check if any files attached to a message are of a certain type and then display all these file types correctly.

Fixes #1784