### PR TITLE
Don't attempt to display contact person if blank

### DIFF
--- a/app/components/profile_header/profile_header.html.erb
+++ b/app/components/profile_header/profile_header.html.erb
@@ -3,8 +3,10 @@
     <%= t('.main_heading', business_plan_name: organization.business_plan.name) %>
   <% end %>
 
-  <%= c 'heading', style: :gamma do %>
-    <%= t('.sub_heading.contact_person', contact_person_name: organization.contact_person.name, contact_person_email: organization.contact_person.email) %>
+  <% if organization.contact_person.present? %>
+    <%= c 'heading', style: :gamma do %>
+      <%= t('.sub_heading.contact_person', contact_person_name: organization.contact_person.name, contact_person_email: organization.contact_person.email) %>
+    <% end %>
   <% end %>
 
   <%= c 'heading', style: :gamma do %>

--- a/app/components/profile_header/profile_header.html.erb
+++ b/app/components/profile_header/profile_header.html.erb
@@ -4,17 +4,17 @@
   <% end %>
 
   <% if organization.contact_person.present? %>
-    <%= c 'heading', style: :gamma do %>
+    <%= c 'heading', tag: :h2, style: :beta, data: { testid: 'contact_person' } do %>
       <%= t('.sub_heading.contact_person', contact_person_name: organization.contact_person.name, contact_person_email: organization.contact_person.email) %>
     <% end %>
   <% end %>
 
-  <%= c 'heading', style: :gamma do %>
+  <%= c 'heading', tag: :h2, style: :beta, data: { testid: 'price_per_month' } do %>
     <%= t('.sub_heading.business_plan.price_per_month', price_per_month: price_per_month) %>
   <% end %>
 
   <% if organization.business_plan.valid_until.present? %>
-    <%= c 'heading', style: :gamma do %>
+    <%= c 'heading', tag: :h2, style: :beta, data: { testid: 'valid_until' } do %>
       <%= t('.sub_heading.business_plan.valid_until', valid_until: I18n.l(organization.business_plan.valid_until, format: '%m/%Y')) %>
     <% end %>
   <% end %>
@@ -28,7 +28,7 @@
       <%= c 'button',
         class: 'ProfileHeader-openModalButton',
         styles: [:secondary],
-        data: { action: 'profile-header#openModal' } do %>
+        data: { action: 'profile-header#openModal', testid: 'upgrade_business_plan_button' } do %>
         <%= svg 'plus-sign' %>
         <%= t('.upgrade_business_plan_button_html', upgrade_discount: organization.upgrade_discount) %>
       <% end%>

--- a/spec/components/profile_header_spec.rb
+++ b/spec/components/profile_header_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProfileHeader::ProfileHeader, type: :component do
+  subject { render_inline(described_class.new(**params)) }
+
+  let(:contact_person) { create(:user, first_name: 'ContactFor', last_name: 'Organization') }
+  let(:organization) do
+    create(:organization,
+           business_plan: editorial_basic,
+           contact_person: contact_person)
+  end
+  let(:editorial_basic) { create(:business_plan, :editorial_basic, valid_from: Time.current, valid_until: 6.months.from_now) }
+  let(:editorial_pro) { create(:business_plan, :editorial_pro) }
+  let(:editorial_enterprise) { create(:business_plan, :editorial_enterprise) }
+  let(:business_plans) { [editorial_basic, editorial_pro, editorial_enterprise] }
+  let(:params) { { organization: organization, business_plans: business_plans } }
+
+  it { is_expected.to have_css('.ProfileHeader') }
+  it { is_expected.to have_text('Editorial Basic') }
+  it { is_expected.to have_selector(:element, 'h2', 'data-testid': 'contact_person', text: 'ContactFor Organization') }
+  it {
+    is_expected.to have_selector(:element, 'h2', 'data-testid': 'price_per_month',
+                                                 text: number_to_currency(organization.business_plan.price_per_month).to_s)
+  }
+  it {
+    is_expected.to have_selector(:element, 'h2', 'data-testid': 'valid_until',
+                                                 text: I18n.l(organization.business_plan.valid_until, format: '%m/%Y').to_s)
+  }
+  it {
+    is_expected.to have_button("Plan jetzt upgraden und #{organization.upgrade_discount}% sparen")
+  }
+
+  context 'No contact person' do
+    before { organization.update!(contact_person: nil) }
+
+    it { is_expected.to have_css('.ProfileHeader') } # doesn't crash with NilError
+    it { is_expected.not_to have_selector(:element, 'h2', 'data-testid': 'contact_person') }
+  end
+
+  context 'Price with discount' do
+    before { organization.update!(upgraded_business_plan_at: 5.minutes.ago) }
+    let(:price_with_discount) do
+      number_to_currency(organization.business_plan.price_per_month -
+      (organization.business_plan.price_per_month * organization.upgrade_discount / 100.to_f))
+    end
+    it {
+      is_expected.not_to have_selector(:element, 'h2', 'data-testid': 'price_per_month',
+                                                       text: number_to_currency(organization.business_plan.price_per_month).to_s)
+    }
+    it {
+      is_expected.to have_selector(:element, 'h2', 'data-testid': 'price_per_month', text: price_with_discount)
+    }
+  end
+
+  context 'No expiration of plan' do
+    before { organization.business_plan.update!(valid_until: nil) }
+
+    it { is_expected.not_to have_selector(:element, 'h2', 'data-testid': 'valid_until') }
+  end
+
+  context 'No upgrade available' do
+    before { organization.update!(business_plan: editorial_enterprise) }
+
+    it { is_expected.not_to have_button('upgrade_business_plan_button') }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,9 +84,14 @@ RSpec.configure do |config|
   # in component specs
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include ActionView::Helpers::NumberHelper, type: :component
   config.include FactoryBot::Syntax::Methods
   config.include ActionView::Helpers::NumberHelper, type: :system
   config.include ActionView::Helpers::NumberHelper, type: :requests
 
   config.include Helpers
+end
+
+Capybara.configure do |config|
+  config.test_id = 'data-testid'
 end


### PR DESCRIPTION
- sometimes we set up an instance before we are giving the information on who the contact person is. Ideally, this would not result in an error if someone visits the profile page