### PR TITLE
Bump puma to v6.3.1 to fix critical security alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 6.1.6.1'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 5.6'
+gem 'puma', '~> 6.3.1'
 # Use Active Storage variant
 gem 'image_processing', '~> 1.12'
 # Reduces boot times through caching; required in config/boot.rb
@@ -37,7 +37,7 @@ end
 
 group :test do
   # Adds support for Capybara system testing
-  gem 'capybara', '>= 2.15'
+  gem 'capybara', '>= 3.38.0'
   gem 'cuprite'
   gem 'db-query-matchers'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,11 +108,11 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.37.1)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -274,7 +274,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.0)
-    puma (5.6.5)
+    puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
@@ -444,7 +444,7 @@ DEPENDENCIES
   browser
   bullet
   byebug
-  capybara (>= 2.15)
+  capybara (>= 3.38.0)
   clearance
   counter_culture (~> 3.3)
   cuprite
@@ -465,7 +465,7 @@ DEPENDENCIES
   phony_rails
   postmark-rails
   pry-rails
-  puma (~> 5.6)
+  puma (~> 6.3.1)
   rack-attack (~> 6.6)
   rails (~> 6.1.6.1)
   rails-settings-cached (~> 2.8)
@@ -491,4 +491,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.3.11
+   2.5.7


### PR DESCRIPTION
See https://github.com/tactilenews/100eyes/security/dependabot/65

There was a breaking change in Puma v6 that required upgrading Capybara together with this.

See [Welcome to Puma 6: Sunflower - Upgrade](https://github.com/puma/puma/blob/master/6.0-Upgrade.md#upgrade)

> We've removed the following public methods on Puma::Server: Puma::Server#min_threads, Puma::Server#max_threads. Instead, you can pass in configuration as an option to Puma::Server#new. This might make certain gems break (capybara for example).