### PR TITLE
Mark Threema outbound messages received/read

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'rack-attack', '~> 6.6'
 # Channel adapters
 gem 'postmark-rails'
 gem 'telegram-bot'
-gem 'threema', git: 'https://github.com/threemarb/threema.git', branch: 'master'
+gem 'threema', git: 'https://github.com/threemarb/threema.git', branch: '39_improve_delivery_receipt_class'
 gem 'twilio-ruby'
 
 # User management

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'rack-attack', '~> 6.6'
 # Channel adapters
 gem 'postmark-rails'
 gem 'telegram-bot'
-gem 'threema', git: 'https://github.com/threemarb/threema.git', branch: '39_improve_delivery_receipt_class'
+gem 'threema', git: 'https://github.com/threemarb/threema.git', branch: 'master'
 gem 'twilio-ruby'
 
 # User management

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/threemarb/threema.git
-  revision: f29f1f94917a29799c61ac950c31981606ada19d
-  branch: master
+  revision: 320be41c35082c25a4f138c5012198b6ec28ec80
+  branch: 39_improve_delivery_receipt_class
   specs:
     threema (0.1.0)
       case_transform
@@ -231,9 +231,9 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2024.0305)
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
@@ -242,7 +242,7 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.16.3)
     msgpack (1.7.1)
-    multipart-post (2.2.3)
+    multipart-post (2.4.0)
     nio4r (2.5.8)
     nokogiri (1.16.3)
       mini_portile2 (~> 2.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/threemarb/threema.git
-  revision: 7f6e30111abee4111bd133960041902f9b683130
-  branch: 39_improve_delivery_receipt_class
+  revision: c8da2843cf154c868f1555f9293f8965562ab727
+  branch: master
   specs:
     threema (0.1.0)
-      case_transform
+      activesupport (<= 7.0.8)
       dotenv
       mime-types
       mimemagic
@@ -117,8 +117,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    case_transform (0.2)
-      activesupport
     chunky_png (1.4.0)
     clearance (2.6.1)
       actionmailer (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/threemarb/threema.git
-  revision: 320be41c35082c25a4f138c5012198b6ec28ec80
+  revision: 7f6e30111abee4111bd133960041902f9b683130
   branch: 39_improve_delivery_receipt_class
   specs:
     threema (0.1.0)

--- a/app/adapters/threema_adapter/inbound.rb
+++ b/app/adapters/threema_adapter/inbound.rb
@@ -5,6 +5,7 @@ module ThreemaAdapter
   UNSUBSCRIBE_CONTRIBUTOR = :unsubscribe_contributor
   RESUBSCRIBE_CONTRIBUTOR = :resubscribe_contributor
   UNSUPPORTED_CONTENT = :unsupported_content
+  HANDLE_DELIVERY_RECEIPT = :handle_delivery_receipt
 
   class Inbound
     UNSUPPORTED_CONTENT_TYPES = %w[application text/x-vcard].freeze
@@ -20,10 +21,11 @@ module ThreemaAdapter
 
     def consume(threema_message)
       decrypted_message = Threema.new.receive(payload: threema_message)
-      return if delivery_receipt?(decrypted_message)
 
       @sender = initialize_sender(threema_message)
       return unless @sender
+
+      trigger(HANDLE_DELIVERY_RECEIPT, decrypted_message) if delivery_receipt?(decrypted_message)
 
       @message = initialize_message(decrypted_message)
       return unless @message

--- a/app/adapters/threema_adapter/inbound.rb
+++ b/app/adapters/threema_adapter/inbound.rb
@@ -25,7 +25,10 @@ module ThreemaAdapter
       @sender = initialize_sender(threema_message)
       return unless @sender
 
-      trigger(HANDLE_DELIVERY_RECEIPT, decrypted_message) if delivery_receipt?(decrypted_message)
+      if delivery_receipt?(decrypted_message)
+        trigger(HANDLE_DELIVERY_RECEIPT, decrypted_message)
+        return
+      end
 
       @message = initialize_message(decrypted_message)
       return unless @message

--- a/app/adapters/threema_adapter/outbound.rb
+++ b/app/adapters/threema_adapter/outbound.rb
@@ -58,7 +58,7 @@ module ThreemaAdapter
       end
 
       def send_text(message)
-        ThreemaAdapter::Outbound::Text.perform_later(contributor_id: message.recipient.id, text: message.text)
+        ThreemaAdapter::Outbound::Text.perform_later(contributor_id: message.recipient.id, text: message.text, message: message)
       end
     end
   end

--- a/app/adapters/threema_adapter/outbound.rb
+++ b/app/adapters/threema_adapter/outbound.rb
@@ -52,7 +52,8 @@ module ThreemaAdapter
             file_path: ActiveStorage::Blob.service.path_for(file.attachment.blob.key),
             file_name: file.attachment.blob.filename.to_s,
             caption: index.zero? ? message.text : nil,
-            render_type: :media
+            render_type: :media,
+            message: message
           )
         end
       end

--- a/app/adapters/threema_adapter/outbound/file.rb
+++ b/app/adapters/threema_adapter/outbound/file.rb
@@ -22,16 +22,19 @@ module ThreemaAdapter
         @threema_instance ||= Threema.new
       end
 
-      def perform(contributor_id:, file_path:, file_name: nil, caption: nil, render_type: nil)
+      def perform(contributor_id:, file_path:, file_name: nil, caption: nil, render_type: nil, message: nil)
         recipient = Contributor.find_by(id: contributor_id)
         return unless recipient
 
-        self.class.threema_instance.send(type: :file,
-                                         threema_id: recipient.threema_id.upcase,
-                                         file: file_path,
-                                         render_type: render_type,
-                                         file_name: file_name,
-                                         caption: caption)
+        message_id = self.class.threema_instance.send(type: :file,
+                                                      threema_id: recipient.threema_id.upcase,
+                                                      file: file_path,
+                                                      render_type: render_type,
+                                                      file_name: file_name,
+                                                      caption: caption)
+        return unless message
+
+        message.update(external_id: message_id)
       end
     end
   end

--- a/app/adapters/threema_adapter/outbound/text.rb
+++ b/app/adapters/threema_adapter/outbound/text.rb
@@ -22,11 +22,15 @@ module ThreemaAdapter
         @threema_instance ||= Threema.new
       end
 
-      def perform(contributor_id:, text: nil)
+      def perform(contributor_id:, text: nil, message: nil)
         recipient = Contributor.find(contributor_id)
         return unless recipient
 
-        self.class.threema_instance.send(type: :text, threema_id: recipient.threema_id.upcase, text: text)
+        message_id = self.class.threema_instance.send(type: :text, threema_id: recipient.threema_id.upcase, text: text)
+
+        return unless message
+
+        message.update(external_id: message_id)
       end
     end
   end

--- a/spec/adapters/threema_adapter/outbound/file_spec.rb
+++ b/spec/adapters/threema_adapter/outbound/file_spec.rb
@@ -21,11 +21,16 @@ RSpec.describe ThreemaAdapter::Outbound::File do
       caption: message.text
     }
   end
+  let(:message_id) { SecureRandom.alphanumeric(16) }
+  let(:threema_lookup_double) { instance_double(Threema::Lookup) }
 
   describe '#perform' do
     before do
       message.reload
-      allow(Threema).to receive(:new).and_return(threema_double)
+      allow(ThreemaAdapter::Outbound::File).to receive(:threema_instance).and_return(threema_double)
+      allow(Threema::Lookup).to receive(:new).and_call_original
+      allow(Threema::Lookup).to receive(:new).with({ threema: threema_double }).and_return(threema_lookup_double)
+      allow(threema_lookup_double).to receive(:key).and_return('PUBLIC_KEY_HEX_ENCODED')
     end
     subject do
       lambda {
@@ -41,6 +46,27 @@ RSpec.describe ThreemaAdapter::Outbound::File do
       expect(threema_double).to receive(:send).with(expected_params)
 
       subject.call
+    end
+
+    context 'when a message is passed in' do
+      subject do
+        lambda {
+          adapter.perform(contributor_id: message.recipient.id,
+                          file_path: file_path,
+                          file_name: message.files.first.attachment.blob.filename.to_s,
+                          caption: message.text,
+                          render_type: :media,
+                          message: message)
+        }
+      end
+
+      before do
+        allow(threema_double).to receive(:send).with(expected_params).and_return(message_id)
+      end
+
+      it "saves the returned message id to the message's external_id" do
+        expect { subject.call }.to change { message.reload.external_id }.from(nil).to(message_id)
+      end
     end
   end
 end

--- a/spec/adapters/threema_adapter/outbound/text_spec.rb
+++ b/spec/adapters/threema_adapter/outbound/text_spec.rb
@@ -9,12 +9,24 @@ RSpec.describe ThreemaAdapter::Outbound::Text do
     build(:contributor, threema_id: threema_id, email: nil).tap { |contributor| contributor.save(validate: false) }
   end
   let(:message) { create(:message, recipient: contributor) }
+  let(:threema_double) { instance_double(Threema) }
+  let(:threema_lookup_double) { instance_double(Threema::Lookup) }
+  let(:message_id) { SecureRandom.alphanumeric(16) }
+
+  before do
+    allow(ThreemaAdapter::Outbound::Text).to receive(:threema_instance).and_return(threema_double)
+    allow(Threema::Lookup).to receive(:new).and_call_original
+    allow(Threema::Lookup).to receive(:new).with({ threema: threema_double }).and_return(threema_lookup_double)
+    allow(threema_lookup_double).to receive(:key).and_return('PUBLIC_KEY_HEX_ENCODED')
+    allow(threema_double).to receive(:send).with(type: :text, threema_id: threema_id, text: message.text).and_return(message_id)
+  end
 
   describe '#perform' do
     subject { -> { adapter.perform(text: message.text, contributor_id: message.recipient.id) } }
 
     it 'sends the message' do
-      expect_any_instance_of(Threema).to receive(:send).with(type: :text, threema_id: 'V5EA564T', text: message.text)
+      expect(threema_double).to receive(:send).with(type: :text, threema_id: threema_id, text: message.text)
+
       subject.call
     end
 
@@ -22,8 +34,17 @@ RSpec.describe ThreemaAdapter::Outbound::Text do
       let(:threema_id) { 'v5ea564t' }
 
       it 'converts ID to uppercase' do
-        expect_any_instance_of(Threema).to receive(:send).with(type: :text, threema_id: 'V5EA564T', text: message.text)
+        expect(threema_double).to receive(:send).with(type: :text, threema_id: threema_id.upcase, text: message.text)
+
         subject.call
+      end
+    end
+
+    context 'when a message is passed in' do
+      subject { -> { adapter.perform(text: message.text, contributor_id: message.recipient.id, message: message) } }
+
+      it "saves the returned message id to the message's external_id" do
+        expect { subject.call }.to change { message.reload.external_id }.from(nil).to(message_id)
       end
     end
   end


### PR DESCRIPTION
using DeliveryReceipts

Closes #1748

### What's changed in this PR and why

* We now save the return of the `Threem.new.send` calls in [ThreemaAdapter::Outbound::Text](https://github.com/tactilenews/100eyes/pull/1842/files#diff-402a3d7c770d8e5816bb7c215e28cde5f65e81704e368d834e8b66d861558387R29-R33)(File) classes and update the message's external id, if it exists. For the welcome message, for example, there is no message record created to update.

* Instead of actively ignoring `Threema::Receive::DeliveryReceipt` in our [TheemaAdapter::Inbound](https://github.com/tactilenews/100eyes/pull/1842/files#diff-c0d65b63d1d94e854e0f4777f3b9ca7e29831d6b11c4e16e9a229ecc46523429R28-R32) class, we now process them by triggering a `HANDLE_DELIVERY_RECEIPT` callback, then checking if we can find the message records by their external_id and updating them if we do in our [Theema::WebhookController](https://github.com/tactilenews/100eyes/pull/1842/files#diff-5989ff533efbd7a65692982960f3051d578004ba1deab854e4b1e1f1ab5588f6R51-R70).

* Only received and read receipts are considered, even though we can receive receipts with statuses `:explicitly_acknowleded` and `:explicitly_declined` as well. See **What is not included in this PR and why** for an explanation of why.

* We handle the case where we receive a single delivery receipt for multiple different message ids with the same status. This happens when someone receives several messages and later opens threema and reads them at the same time. I suspect it also happens if one has their phone turned off and receives several at the same time, though I have not manually tested this.

* If we cannot find the message by its `external_id`, it is a no-op as `messages = Message.where(external_id: delivery_receipt.message_ids)` will return an empty array.

* We also check if the message record has not had the `received_at` set while we mark the `read_at`. There was one time during manually testing that it seems we did not receive a received receipt for a message, but we did receive a read one. I think it's safe to say that if they have read the message, they also received it.

* The changes made to Gemfile* can be considered as temporary and will be reverted once the changes  from [Improve Threema::Receive::DeliveryReceipt class #40](https://github.com/threemarb/threema/pull/40) have been merged in.

### What's not included in this PR and why

* We actively ignore `:explicitly_acknowledged` and `:explicitly_declined` receipts. I have not tested this, but it is my understanding that this is when a threema user long clicks on the message and gives it a thumbs up or down respectively. The reason we did not do anything in this PR is that the messengers have different ways of handling these interactions. Our contributors should not be expected to know that these interactions will be ignored, so  I do not want to lose this information by ignoring it.

I think further discussion on how we should handle it is warranted. I don't think adding other attributes  `:explicitly_acknowledged_at` and `:explicitly_declined_at` would be warranted since it only happens for Threema.

In my opinion, we should not treat them as delivery receipts at all, but treat them as text with the emojis :+1:  :-1: . This is similar to how we receive the information from Signal, which also provides a way to react with emojis. See [SignalAdapter::Inbound specs](https://github.com/tactilenews/100eyes/blob/main/spec/adapters/signal_adapter/inbound_spec.rb#L266-L269). Telegram does not offer this feature, it seems. WhatsApp does, but it's unclear how it's handled.

### Testing

As long as we don't merge anything in that gets automatically deployed, one can test this at staging.100ey.es ... I've deployed a custom image there that allows testing.
