### PR TITLE
Add basic stats with breakdown of channels counts

### DIFF
--- a/app/components/admin_stats/admin_stats.html.erb
+++ b/app/components/admin_stats/admin_stats.html.erb
@@ -1,0 +1,8 @@
+<section style="padding: 20px">
+  <h1 style="padding-bottom: 20px">Stats</h1>
+  <p><strong>Email contributors:</strong> <%= email_contributors_count %></p>
+  <p><strong>Threema contributors:</strong> <%= threema_contributors_count %></p>
+  <p><strong>Telegram contributors:</strong> <%= telegram_contributors_count %></p>
+  <p><strong>Signal contributors:</strong> <%= signal_contributors_count %></p>
+  <p><strong>WhatsApp contributors:</strong> <%= whats_app_contributors_count %></p>
+</section>

--- a/app/components/admin_stats/admin_stats.rb
+++ b/app/components/admin_stats/admin_stats.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module AdminStats
+  class AdminStats < ApplicationComponent
+    def initialize(stats:)
+      super
+
+      @stats = stats
+    end
+
+    attr_reader :stats
+
+    def email_contributors_count
+      stats[:email_contributors_count]
+    end
+
+    def threema_contributors_count
+      stats[:threema_contributors_count]
+    end
+
+    def telegram_contributors_count
+      stats[:telegram_contributors_count]
+    end
+
+    def signal_contributors_count
+      stats[:signal_contributors_count]
+    end
+
+    def whats_app_contributors_count
+      stats[:whats_app_contributors_count]
+    end
+  end
+end

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Admin
+  class StatsController < Admin::ApplicationController
+    def index
+      @stats = {
+        email_contributors_count: Contributor.with_email.count,
+        threema_contributors_count: Contributor.with_threema.count,
+        telegram_contributors_count: Contributor.with_telegram.count,
+        signal_contributors_count: Contributor.with_signal.count,
+        whats_app_contributors_count: Contributor.with_whats_app.count
+      }
+      render AdminStats::AdminStats.new(stats: @stats)
+    end
+  end
+end

--- a/app/dashboards/stat_dashboard.rb
+++ b/app/dashboards/stat_dashboard.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'administrate/custom_dashboard'
+
+class StatDashboard < Administrate::CustomDashboard
+  resource 'Stats' # used by administrate in the views
+end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -51,6 +51,12 @@ class Contributor < ApplicationRecord
     tag_list.blank? ? all : tagged_with(tag_list)
   }
 
+  scope :with_email, -> { where.not(email: nil) }
+  scope :with_threema, -> { where.not(threema_id: nil) }
+  scope :with_telegram, -> { where.not(telegram_id: nil) }
+  scope :with_signal, -> { where.not(signal_phone_number: nil, signal_onboarding_completed_at: nil) }
+  scope :with_whats_app, -> { where.not(whats_app_phone_number: nil) }
+
   before_validation do
     self.email = nil if email.blank?
     self.threema_id = nil if threema_id.blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
       resources :delayed_jobs, only: %i[index show destroy]
       resources :business_plans, only: %i[index show edit update]
       resources :organizations, only: %i[index show edit update]
+      resources :stats, only: [:index]
     end
   end
 

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryBot.define do
   factory :contributor do
     first_name { 'John' }
@@ -15,5 +16,35 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :threema_contributor do
+      after(:build) do |contributor|
+        contributor.email = nil
+        contributor.threema_id = Faker::String.random(length: 8)
+      end
+    end
+
+    trait :telegram_contributor do
+      after(:build) do |contributor|
+        contributor.email = nil
+        contributor.telegram_id = Faker::Number.number(digits: 9)
+      end
+    end
+
+    trait :signal_contributor do
+      after(:build) do |contributor|
+        contributor.email = nil
+        contributor.signal_phone_number = Faker::PhoneNumber.cell_phone_in_e164
+        contributor.signal_onboarding_completed_at = Time.current
+      end
+    end
+
+    trait :whats_app_contributor do
+      after(:build) do |contributor|
+        contributor.email = nil
+        contributor.whats_app_phone_number = Faker::PhoneNumber.cell_phone_in_e164
+      end
+    end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
         contributor.whats_app_phone_number = Faker::PhoneNumber.cell_phone_in_e164
       end
     end
+
+    trait :skip_validations do
+      to_create { |instance| instance.save(validate: false) }
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe 'Stats' do
     let(:mock_validator) { instance_double(ThreemaValidator) }
 
     before do
-      allow(ThreemaValidator).to receive(:new).and_return(mock_validator)
-      allow(mock_validator).to receive(:validate).and_return(nil)
       create_list(:contributor, 3)
-      create_list(:contributor, 2, :threema_contributor)
+      create_list(:contributor, 2, :threema_contributor, :skip_validations)
       create_list(:contributor, 4, :telegram_contributor)
       create_list(:contributor, 6, :signal_contributor)
       create_list(:contributor, 12, :whats_app_contributor)

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Stats' do
+  context 'as admin' do
+    let(:user) { create(:user, admin: true) }
+    let(:mock_validator) { instance_double(ThreemaValidator) }
+
+    before do
+      allow(ThreemaValidator).to receive(:new).and_return(mock_validator)
+      allow(mock_validator).to receive(:validate).and_return(nil)
+      create_list(:contributor, 3)
+      create_list(:contributor, 2, :threema_contributor)
+      create_list(:contributor, 4, :telegram_contributor)
+      create_list(:contributor, 6, :signal_contributor)
+      create_list(:contributor, 12, :whats_app_contributor)
+    end
+
+    it 'admin edits contributor' do
+      visit admin_stats_path(as: user)
+
+      expect(page).to have_content('Email contributors: 3')
+      expect(page).to have_content('Threema contributors: 2')
+      expect(page).to have_content('Telegram contributors: 4')
+      expect(page).to have_content('Signal contributors: 6')
+      expect(page).to have_content('WhatsApp contributors: 12')
+    end
+  end
+end


### PR DESCRIPTION
### What changed in this PR and why

Added a tab in the admin page for stats. This page currently simply has the count of contributors by channel.
It does not filter out for active contributors or anything else currently.

### Whats not included in this PR and why

Currently, it seems pretty limited what we can easily achieve with administrate gem. Our css styles do not get loaded or applied and we cannot connect to our stimulus controllers without overriding administrate's js files, it seems. Have not tried. It might be nice to have a pie chart that displays this info.

Maybe, we could display info on our dashboard page? Is it only interesting for admin? If we wanted to scope it to admin only, we could easily add a flag to display it only to admin.

Closes #1861 

