### PR TITLE
[refactor] specs to use skip validations trait

### DIFF
--- a/spec/adapters/threema_adapter/inbound_spec.rb
+++ b/spec/adapters/threema_adapter/inbound_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ThreemaAdapter::Inbound do
   let(:threema_id) { 'V5EA564T' }
-  let!(:contributor) { build(:contributor, threema_id: threema_id).tap { |contributor| contributor.save(validate: false) } }
+  let!(:contributor) { create(:contributor, :skip_validations, threema_id: threema_id) }
 
   let(:adapter) { described_class.new }
   let(:threema_message) do

--- a/spec/adapters/threema_adapter/outbound/file_spec.rb
+++ b/spec/adapters/threema_adapter/outbound/file_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe ThreemaAdapter::Outbound::File do
   let(:adapter) { described_class.new }
   let(:threema_double) { instance_double(Threema) }
   let(:threema_id) { 'V5EA564T' }
-  let(:contributor) do
-    build(:contributor, threema_id: threema_id, email: nil).tap { |contributor| contributor.save(validate: false) }
-  end
+  let(:contributor) { create(:contributor, :skip_validations, threema_id: threema_id, email: nil) }
   let(:message) { create(:message, :with_file, recipient: contributor) }
   let(:file_path) { ActiveStorage::Blob.service.path_for(message.files.first.attachment.blob.key) }
   let(:expected_params) do

--- a/spec/adapters/threema_adapter/outbound/text_spec.rb
+++ b/spec/adapters/threema_adapter/outbound/text_spec.rb
@@ -5,9 +5,7 @@ require 'rails_helper'
 RSpec.describe ThreemaAdapter::Outbound::Text do
   let(:adapter) { described_class.new }
   let(:threema_id) { 'V5EA564T' }
-  let(:contributor) do
-    build(:contributor, threema_id: threema_id, email: nil).tap { |contributor| contributor.save(validate: false) }
-  end
+  let(:contributor) { create(:contributor, :skip_validations, threema_id: threema_id, email: nil) }
   let(:message) { create(:message, recipient: contributor) }
   let(:threema_double) { instance_double(Threema) }
   let(:threema_lookup_double) { instance_double(Threema::Lookup) }

--- a/spec/adapters/threema_adapter/outbound_spec.rb
+++ b/spec/adapters/threema_adapter/outbound_spec.rb
@@ -4,9 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ThreemaAdapter::Outbound do
   let(:threema_id) { 'V5EA564T' }
-  let(:contributor) do
-    build(:contributor, threema_id: threema_id, email: nil).tap { |contributor| contributor.save(validate: false) }
-  end
+  let(:contributor) { create(:contributor, :skip_validations, threema_id: threema_id, email: nil) }
   let(:message) { create(:message, recipient: contributor) }
 
   describe '::send!' do

--- a/spec/components/contributor_channel_settings_spec.rb
+++ b/spec/components/contributor_channel_settings_spec.rb
@@ -5,9 +5,7 @@ require 'rails_helper'
 RSpec.describe ContributorChannelSettings::ContributorChannelSettings, type: :component do
   subject { render_inline(described_class.new(**params)) }
 
-  let(:contributor) do
-    build(:contributor, email: nil, **attrs).tap { |contributor| contributor.save(validate: false) }
-  end
+  let(:contributor) { create(:contributor, email: nil, **attrs) }
   let(:attrs) { {} }
   let(:params) { { contributor: contributor } }
 
@@ -24,6 +22,7 @@ RSpec.describe ContributorChannelSettings::ContributorChannelSettings, type: :co
   end
 
   context 'given a Threema contributor' do
+    let(:contributor) { create(:contributor, :skip_validations, email: nil, **attrs) }
     let(:attrs) { { threema_id: 12_345_678 } }
     it { should have_css('h2', text: 'Threema') }
   end

--- a/spec/components/contributor_threema_settings_spec.rb
+++ b/spec/components/contributor_threema_settings_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe ContributorThreemaSettings::ContributorThreemaSettings, type: :co
   subject { render_inline(described_class.new(**params)) }
 
   let(:contributor) do
-    build(:contributor,
-          first_name: 'Max',
-          last_name: 'Mustermann',
-          threema_id: '12345678',
-          created_at: '2021-01-01').tap { |contributor| contributor.save(validate: false) }
+    create(:contributor,
+           :skip_validations,
+           first_name: 'Max',
+           last_name: 'Mustermann',
+           threema_id: '12345678',
+           created_at: '2021-01-01')
   end
   let(:params) { { contributor: contributor } }
 

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -453,9 +453,7 @@ RSpec.describe Contributor, type: :model do
         end
       end
       let(:threema_id) { 'V5EA564T' }
-      let!(:contributor) do
-        build(:contributor, threema_id: threema_id).tap { |contributor| contributor.save(validate: false) }
-      end
+      let!(:contributor) { create(:contributor, :skip_validations, threema_id: threema_id) }
 
       before do
         allow(Threema).to receive(:new).and_return(threema)
@@ -835,9 +833,7 @@ RSpec.describe Contributor, type: :model do
 
     context 'signed up via threema' do
       let(:expected_job_args) { { contributor_id: contributor.id, text: "*Welcome new contributor!*\nYou onboarded successfully." } }
-      let(:contributor) do
-        build(:contributor, threema_id: 'AAAAAAAA', email: nil, telegram_id: nil).tap { |contributor| contributor.save(validate: false) }
-      end
+      let(:contributor) { create(:contributor, :skip_validations, threema_id: 'AAAAAAAA', email: nil, telegram_id: nil) }
       it { should enqueue_job(ThreemaAdapter::Outbound::Text).with(expected_job_args) }
     end
 

--- a/spec/requests/contributors_spec.rb
+++ b/spec/requests/contributors_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe '/contributors', type: :request do
     end
 
     context 'given a manually created contributor' do
-      let(:contributor) { build(:contributor, data_processing_consent: false, first_name: 'John').tap { |c| c.save(validate: false) } }
+      let(:contributor) { create(:contributor, :skip_validations, data_processing_consent: false, first_name: 'John') }
 
       it 'updates contributor' do
         expect { subject.call }.to(change { contributor.reload.first_name }.from('John').to('Zora'))
@@ -122,7 +122,7 @@ RSpec.describe '/contributors', type: :request do
     context 'given a Threema contributor' do
       let(:threema) { instance_double(Threema) }
       let(:threema_lookup_double) { instance_double(Threema::Lookup) }
-      let(:contributor) { build(:contributor, threema_id: 'VALID123').tap { |contributor| contributor.save(validate: false) } }
+      let(:contributor) { create(:contributor, :skip_validations, threema_id: 'VALID123') }
       let(:new_attrs) { { threema_id: 'INVALID!' } }
 
       before do

--- a/spec/requests/threema/webhook_spec.rb
+++ b/spec/requests/threema/webhook_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Threema::WebhookController do
     end
 
     context 'With known contributor' do
-      let!(:contributor) { build(:contributor, threema_id: 'V5EA564T').tap { |contributor| contributor.save(validate: false) } }
+      let!(:contributor) { create(:contributor, :skip_validations, threema_id: 'V5EA564T') }
       let!(:request) { create(:request) }
 
       before do

--- a/spec/system/requests/sending_images_spec.rb
+++ b/spec/system/requests/sending_images_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Sending image files', js: true do
       create(:contributor, email: 'adam@example.org')
       create(:contributor, signal_phone_number: '+4912345678', signal_onboarding_completed_at: Time.current)
       create(:contributor, telegram_id: 125_689)
-      build(:contributor, threema_id: '12345678').tap { |contributor| contributor.save(validate: false) }
+      create(:contributor, :skip_validations, threema_id: '12345678')
     end
 
     it 'sending a request with image files' do


### PR DESCRIPTION
### What changed in this PR and why

We recently added a new trait in the contributors factory to skip validations in https://github.com/tactilenews/100eyes/pull/1862. This is useful as we do this to bypass our ThreemaValidator ensuring that we do not create/update threema_id to invalid values. This PR refactors to make use of this trait to DRY out the code.