### PR TITLE
refactor: avoid null-byte characters

### DIFF
--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     trait :threema_contributor do
       after(:build) do |contributor|
         contributor.email = nil
-        contributor.threema_id = Faker::String.random(length: 8)
+        contributor.threema_id = Faker::Alphanumeric.alpha(number: 8)
       end
     end
 


### PR DESCRIPTION
Motivation
----------
This is a better way of avoiding null-byte characters when creating fake Threema IDs for testing.
See this commit: https://github.com/tactilenews/100eyes/pull/1878/commits/f8fb2d7d66e500cff7583e3a3fc8cacc60794793

How to test
-----------
1. `bin/rspec`
2. Tests pass (hopefully more reliably)