### PR TITLE
docs: update ansible requirements locally

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -3,7 +3,7 @@
 Our setup uses a number of community-maintained Ansibles roles. Install them using the `ansible-galaxy` command:
 
 ```
-$ ansible-galaxy install -r ansible/requirements.yml
+$ ansible-galaxy install -r ansible/requirements.yml --force
 ```
 
 Generate configuration files:


### PR DESCRIPTION
Motivation
----------
Without `--force` requirements are never updated to the latest version.

How to test
-----------
1. `ansible-galaxy list`
2. Follow the README.
3. `ansible-galaxy list` displays latest versions