### PR TITLE
Remove superfluous db service from production

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -38,11 +38,15 @@ services:
 
   job-worker:
     <<: *x-dev-defaults
+    depends_on: [ db ]
 
   db:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports: [ '5432:5432' ]
+    image: postgres:14.3-alpine3.16
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   mailserver:
     image: maildev/maildev:2.0.2
@@ -63,3 +67,7 @@ services:
       # Set connection timeout to avoid timeout exception during debugging
       # https://docs.browserless.io/docs/docker.html#connection-timeout
       CONNECTION_TIMEOUT: 600000
+
+volumes:
+  postgres_data:
+ 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,13 +45,6 @@ services:
     <<: *x-prod-defaults
     restart: always
 
-  db:
-    environment:
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
-      POSTGRES_USER: "${POSTGRES_USER}"
-      POSTGRES_DB: "${POSTGRES_DB:-app_production}"
-    restart: always
-
   job-worker:
     <<: *x-prod-defaults
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,17 +15,12 @@ services:
   app:
     <<: *x-defaults
     command: bundle exec rails server
-    depends_on: [ db, job-worker ]
+    depends_on: [ job-worker ]
 
   job-worker:
     <<: *x-defaults
     command: bundle exec rails jobs:work
-    depends_on: [ db, signal ]
-
-  db:
-    image: postgres:14.3-alpine3.16
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
+    depends_on: [ signal ]
 
   signal:
     image: bbernhard/signal-cli-rest-api:0.81
@@ -36,5 +31,4 @@ services:
       - "8080:8080" #map docker port 8080 to host port 8080.
     volumes:
       - ./signal-cli-config:/home/.local/share/signal-cli
-volumes:
-  postgres_data:
+


### PR DESCRIPTION
### What changed in this PR and why

We are using managed dbs and do not need a db service in production. It has been moved to the override to use for local development.