### PR TITLE
fix: docker compose version deprecation

### DIFF
--- a/docker-compose.local-backup.yml
+++ b/docker-compose.local-backup.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   db:
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-dev-defaults: &x-dev-defaults
   build:
     context: .
@@ -70,4 +68,4 @@ services:
 
 volumes:
   postgres_data:
- 
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-prod-defaults: &x-prod-defaults
   image: "tactilenews/hundred-eyes:${DOCKER_IMAGE_TAG:-latest}"
   environment:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   reverse-proxy:
     # The official v2 Traefik docker image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-defaults: &x-defaults
   environment:
     BINDING: 0.0.0.0


### PR DESCRIPTION
Motivation
----------
I keep seeing:
```
WARN[0000] /home/robert/Development/tactile.news/100eyes-closed/100eyes/docker-compose.yml: `version` is obsolete
WARN[0000] /home/robert/Development/tactile.news/100eyes-closed/100eyes/docker-compose.override.yml: `version` is obsolete
```

How to test
-----------
1. `docker compose up`
2. No warnings anymore