### PR TITLE
Clarify manual message feature

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -25,7 +25,7 @@ de:
     chat_messages_group:
       conversations: Verlauf
       reply: antworten
-      add_message: Antwort manuell hinzufügen
+      add_message: Notiz hinzufügen
     chat_form:
       reply_to_reference: "Zur Nachricht: \"%{text}\""
       placeholder: Gib hier deine Nachfrage ein. Referenziere falls nötig die entsprechende Nachricht...
@@ -671,7 +671,7 @@ de:
       success: Die Nachricht wurde erfolgreich verschoben
       error: Die Nachricht konnte nicht verschoben werden
     create:
-      heading: Antwort manuell hinzufügen
+      heading: Notiz hinzufügen
       text: Hier kannst du manuell Antworten von <strong>%{name}</strong> zur Frage <strong>„%{title}”</strong> hinzufügen.
       success: Die Antwort wurde hinzugefügt
       error: Die Antwort konnte nicht hinzugefügt werden


### PR DESCRIPTION
### What changed in this PR and why

It was recently brought to our attention that some clients use the add manual message feature as a reply to feature. This is problematic as the user seems not to realize that these messages never get sent out to the contributor. See discussion https://tactilenews.slack.com/archives/C010QDQLCKW/p1718827095250699 where it was suggested that we attempt to clarify the language around the feature before taking further actions to disable it by default and only enable it for those that request it.