### PR TITLE
build: add image tag to docker-compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,5 @@
 x-dev-defaults: &x-dev-defaults
+  image: tactilenews/hundred-eyes:latest
   build:
     context: .
   environment:


### PR DESCRIPTION
Motivation
----------
I have difficulties to build the docker image right now. It blocks me from doing my work. I was thinking of skipping to buld the image locally and simply download the current uploaded docker image on dockerhub.

For this to work, we need to set `image` in the `docker-compose.yml`. The default behaviour will be that it downloads the image from dockerhub first, instead of building it locally. We can still force the build with `docker compose build`. Is this a reasonable change?

How to test
-----------
1. Remove docker images from your machine with `docker images` and `docker rmi <image_id>`
2. Run `docker compose up`
3. Docker image being pulled instead of built