### PR TITLE
test: regression test for #1914

### DIFF
--- a/spec/jobs/signal_adapter/receive_polling_job_spec.rb
+++ b/spec/jobs/signal_adapter/receive_polling_job_spec.rb
@@ -155,6 +155,17 @@ RSpec.describe SignalAdapter::ReceivePollingJob, type: :job do
           end
         end
       end
+
+      describe 'given a delivery receipt', vcr: { cassette_name: :receive_signal_delivery_receipt } do
+        # Use signal-ci directly to send out a message to the `signal_uuid` below
+        let(:contributor) do
+          create(:contributor, signal_uuid: '4c941782-a59c-4428-a19f-8d7628b6ca42', signal_onboarding_completed_at: 2.weeks.ago)
+        end
+        let!(:message) { create(:message, recipient: contributor) }
+        it 'updates message.received_at (#1914)' do
+          expect { subject.call }.to change { message.reload.received_at }.from(nil).to(Time.zone.at(1_719_664_635))
+        end
+      end
     end
 
     describe 'given a known contributor requests to unsubscribe', vcr: { cassette_name: :receive_signal_message_to_unsubscribe } do

--- a/vcr_cassettes/receive_signal_delivery_receipt.yml
+++ b/vcr_cassettes/receive_signal_delivery_receipt.yml
@@ -1,0 +1,33 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/v1/receive/SIGNAL_SERVER_PHONE_NUMBER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Sat, 29 Jun 2024 12:45:05 GMT
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[{\"envelope\":{\"source\":\"4c941782-a59c-4428-a19f-8d7628b6ca42\",\"sourceNumber\":null,\"sourceUuid\":\"4c941782-a59c-4428-a19f-8d7628b6ca42\",\"sourceName\":\"Robert Schäfer\",\"sourceDevice\":1,\"timestamp\":1719664644151,\"receiptMessage\":{\"when\":1719664644151,\"isDelivery\":true,\"isRead\":false,\"isViewed\":false,\"timestamps\":[1719664633851]}},\"account\":\"+4912345678\"},{\"envelope\":{\"source\":\"4c941782-a59c-4428-a19f-8d7628b6ca42\",\"sourceNumber\":null,\"sourceUuid\":\"4c941782-a59c-4428-a19f-8d7628b6ca42\",\"sourceName\":\"Robert Schäfer\",\"sourceDevice\":1,\"timestamp\":1719664644344,\"receiptMessage\":{\"when\":1719664644344,\"isDelivery\":false,\"isRead\":true,\"isViewed\":false,\"timestamps\":[1719664633851]}},\"account\":\"+4912345678\"},{\"envelope\":{\"source\":\"4c941782-a59c-4428-a19f-8d7628b6ca42\",\"sourceNumber\":null,\"sourceUuid\":\"4c941782-a59c-4428-a19f-8d7628b6ca42\",\"sourceName\":\"Robert Schäfer\",\"sourceDevice\":2,\"timestamp\":1719664635059,\"receiptMessage\":{\"when\":1719664635059,\"isDelivery\":true,\"isRead\":false,\"isViewed\":false,\"timestamps\":[1719664633851]}},\"account\":\"+4912345678\"}]"
+  recorded_at: Sat, 29 Jun 2024 12:45:05 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Motivation
----------
PR #1914 did not regression test the bug, so we're doing it here.

Note that we ran into non-reproducible errors in the test setup with `vcr`. @mattwr18 and I could only receive the signal messages only once during our pair-programming and then nothing anymore, no matter what I tried on my Signal app on my phone or desktop.

We captured the three received messages from the shell history and put it manually into the `vcr` cassette.

How to test
-----------
1. `bin/rspec spec/jobs/signal_adapter/receive_polling_job_spec.rb:159`
2. Test passes
3. `git revert b254b9a62fe980742a2db72762414180469dac17`
4. `bin/rspec spec/jobs/signal_adapter/receive_polling_job_spec.rb:159`
5. Test fails