### PR TITLE
Favor telegram webhook method in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ We're using [our own fork](https://github.com/tactilenews/threema) of the `three
 bundle config local.threema .
 ```
 
+#### Telegram
+
+To test out Telegram webhooks, you need to first set the webhook. You can do this like so:
+
+```rb
+Telegram.bots_config
+{ <key>: <Telegram::Bot::Client> }
+bot = Telegram.bots[<key_of_bot>]
+bot.set_webhook(url: 'https://<localtunnel>/telegram/<route-to-telegram-bot>')
+```
+
 See this [blog post](https://rossta.net/blog/how-to-specify-local-ruby-gems-in-your-gemfile.html) for more information.
 
 ### Testing

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,10 +17,6 @@ x-dev-defaults: &x-dev-defaults
     - .:/app
 
 services:
-  telegram:
-    <<: *x-dev-defaults
-    command: rake telegram:bot:poller
-
   app:
     <<: *x-dev-defaults
     depends_on: [ db, mailserver, assets ]


### PR DESCRIPTION
### What changed in this PR and why

Telegram runs in bot poller mode in development by default. This can be convenient, but has some limitations. It requires having either the bot key configured in env variables or have a default bot set. Moving to introduce multi-tenancy means that we will not longer have a default bot configured. We could set `BOT=1` in our .env variables, but this has some downsides as well, most importantly it will not work for testing multiple bots. One can manually run the `Telegram::Bot::UpdatesPoller .fetch_updates`, but this requires a manual step and more importantly is not how Telegram works in production.

Documentation has been added for setting the webhook, which will work for multiple bots as well.