### PR TITLE
Report ActiveRecord::RecordNotFound errors to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,5 +4,6 @@ Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger]
   config.capture_exception_frame_locals = true
   config.server_name = ENV['APPLICATION_HOSTNAME'] if ENV['APPLICATION_HOSTNAME'].present?
+  config.excluded_exceptions -= ['ActiveRecord::RecordNotFound']
   config.excluded_exceptions += ['ErrorNotifier::IgnoredError']
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,6 +4,9 @@ Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger]
   config.capture_exception_frame_locals = true
   config.server_name = ENV['APPLICATION_HOSTNAME'] if ENV['APPLICATION_HOSTNAME'].present?
-  config.excluded_exceptions -= ['ActiveRecord::RecordNotFound']
-  config.excluded_exceptions += ['ErrorNotifier::IgnoredError']
+  unignored_exceptions = ['ActiveRecord::RecordNotFound']
+  ignored_exceptions = ['ErrorNotifier::IgnoredError']
+
+  config.excluded_exceptions -= unignored_exceptions
+  config.excluded_exceptions += ignored_exceptions
 end


### PR DESCRIPTION
these errors are excluded by default with sentry-ruby

Fixes #1942 