### PR TITLE
Avoid infinite loop in postmark

### DIFF
--- a/app/adapters/postmark_adapter/outbound.rb
+++ b/app/adapters/postmark_adapter/outbound.rb
@@ -51,7 +51,7 @@ module PostmarkAdapter
       end
 
       def contributor_marked_as_inactive!(admin, contributor)
-        return unless admin&.email && admin&.admin? && contributor&.id
+        return unless admin&.email && admin&.admin? && contributor&.id && admin.email != contributor.email
 
         with(admin: admin, contributor: contributor).contributor_marked_as_inactive_email.deliver_later
       end

--- a/spec/adapters/postmark_adapter/outbound_spec.rb
+++ b/spec/adapters/postmark_adapter/outbound_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe PostmarkAdapter::Outbound, type: :mailer do
         end
       end
 
-      context 'user, not admin' do
+      context 'user without an admin role' do
         let(:admin) { build(:user) }
         let(:contributor) { create(:contributor) }
 
@@ -319,18 +319,18 @@ RSpec.describe PostmarkAdapter::Outbound, type: :mailer do
         end
       end
 
-      context 'admin email equals contributo marked inactive email' do
-        let(:admin) { build(:user, id: 231_123, admin: true, email: 'my-email@example.org') }
-        let(:contributor) { build(:contributor, id: 231_123, email: 'my-email@example.org') }
+      context 'admin email equals contributor email' do
+        let(:admin) { create(:user, admin: true, email: 'my-email@example.org') }
+        let(:contributor) { create(:contributor, email: 'my-email@example.org') }
 
         it 'does not enqueue a Mailer' do
           expect { subject }.not_to have_enqueued_job
         end
       end
 
-      context 'with an admin and contributor' do
-        let(:admin) { create(:user, admin: true) }
-        let(:contributor) { create(:contributor) }
+      context 'with an admin and contributor without the same email address' do
+        let(:admin) { create(:user, admin: true, email: 'admin@example.org') }
+        let(:contributor) { create(:contributor, email: 'contributor@example.org') }
 
         it 'enqueues a Mailer' do
           expect { subject }.to have_enqueued_job.on_queue('default').with(

--- a/spec/adapters/postmark_adapter/outbound_spec.rb
+++ b/spec/adapters/postmark_adapter/outbound_spec.rb
@@ -288,5 +288,62 @@ RSpec.describe PostmarkAdapter::Outbound, type: :mailer do
         end
       end
     end
+
+    describe '::contributor_marked_as_inactive!' do
+      subject { described_class.contributor_marked_as_inactive!(admin, contributor) }
+
+      context 'no admin' do
+        let(:admin) { nil }
+        let(:contributor) { create(:contributor) }
+
+        it 'does not enqueue a Mailer' do
+          expect { subject }.not_to have_enqueued_job
+        end
+      end
+
+      context 'no contributor' do
+        let(:admin) { build(:user, admin: true) }
+        let(:contributor) { nil }
+
+        it 'does not enqueue a Mailer' do
+          expect { subject }.not_to have_enqueued_job
+        end
+      end
+
+      context 'user, not admin' do
+        let(:admin) { build(:user) }
+        let(:contributor) { create(:contributor) }
+
+        it 'does not enqueue a Mailer' do
+          expect { subject }.not_to have_enqueued_job
+        end
+      end
+
+      context 'admin email equals contributo marked inactive email' do
+        let(:admin) { build(:user, id: 231_123, admin: true, email: 'my-email@example.org') }
+        let(:contributor) { build(:contributor, id: 231_123, email: 'my-email@example.org') }
+
+        it 'does not enqueue a Mailer' do
+          expect { subject }.not_to have_enqueued_job
+        end
+      end
+
+      context 'with an admin and contributor' do
+        let(:admin) { create(:user, admin: true) }
+        let(:contributor) { create(:contributor) }
+
+        it 'enqueues a Mailer' do
+          expect { subject }.to have_enqueued_job.on_queue('default').with(
+            'PostmarkAdapter::Outbound',
+            'contributor_marked_as_inactive_email',
+            'deliver_now', # How ActionMailer works in test environment, even though in production we call deliver_later
+            {
+              params: { admin: admin, contributor: contributor },
+              args: []
+            }
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
if we try to send a message to an admin notifying them that a contributor is inactive, but that admin has the same email as the contributor who has unsubscribed, it gets stuck in an infinite loop

Fixes #1941 