### PR TITLE
refactor: OrganizationComponent

### DIFF
--- a/app/components/organization_component.rb
+++ b/app/components/organization_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class OrganizationComponent < ApplicationComponent
+  def initialize(organization:, **)
+    @organization = organization
+
+    super
+  end
+
+  attr_reader :organization
+end


### PR DESCRIPTION
remaining code from #1949

- OrganizationComponent class has been added that provides access to the organization helper method to prevent prop drilling

Co-authored-by: Samuel Oey <samuel.oey@gmail.com>

