### PR TITLE
refa: move the whats app namespace in the named scope

### DIFF
--- a/app/components/whats_app_setup/whats_app_setup.rb
+++ b/app/components/whats_app_setup/whats_app_setup.rb
@@ -13,7 +13,7 @@ module WhatsAppSetup
     private
 
     def permissions_url
-      "https://hub.360dialog.com/dashboard/app/#{ENV.fetch('THREE_SIXTY_DIALOG_PARTNER_ID', '')}/permissions?redirect_url=#{CGI.escape(whats_app_onboarding_successful_url(organization_id))}"
+      "https://hub.360dialog.com/dashboard/app/#{ENV.fetch('THREE_SIXTY_DIALOG_PARTNER_ID', '')}/permissions?redirect_url=#{CGI.escape(organization_whats_app_onboarding_successful_url(organization_id))}"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,14 @@ Rails.application.routes.draw do
   end
 
   get '/dashboard', to: 'dashboard#index'
+  scope ':organization_id', as: 'organization', constraints: { organization_id: /\d+/ } do
+    # TODO: Move each unscoped controller here if it has to be scoped by its organization
+
+    namespace :whats_app do
+      get '/onboarding-successful', to: 'three_sixty_dialog_webhook#create_api_key'
+      post '/three-sixty-dialog-webhook', to: 'three_sixty_dialog_webhook#message'
+    end
+  end
   get '/search', to: 'search#index'
   get '/health', to: 'health#index'
   get '/about', to: 'about#index'
@@ -48,13 +56,6 @@ Rails.application.routes.draw do
     post '/webhook', to: 'webhook#message'
     post '/errors', to: 'webhook#errors'
     post '/status', to: 'webhook#status'
-  end
-
-  scope ':organization_id' do
-    namespace :whats_app do
-      get '/onboarding-successful', to: 'three_sixty_dialog_webhook#create_api_key'
-      post '/three-sixty-dialog-webhook', to: 'three_sixty_dialog_webhook#message'
-    end
   end
 
   Telegram.bots.each do |(_name, bot)|

--- a/spec/requests/whats_app/three_sixty_dialog_webhook_spec.rb
+++ b/spec/requests/whats_app/three_sixty_dialog_webhook_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WhatsApp::ThreeSixtyDialogWebhookController do
   end
   let(:latest_message) { contributor.received_messages.first.text }
 
-  subject { -> { post whats_app_three_sixty_dialog_webhook_path(organization), params: params } }
+  subject { -> { post organization_whats_app_three_sixty_dialog_webhook_path(organization), params: params } }
 
   describe '#messages' do
     before do


### PR DESCRIPTION
This is adds some fundamentals that are needed in each of the upcoming pull requests to scope the routes to their organization:

- A route scope is added where every resource can be moved that has to be scoped by the organization
- Added a organization helper method that returns the current organization context
- Organization context retrieval has been changed that it looks up the DB entry if the param is given
- OrganizationComponent class has been added that provides access to the organization helper method to prevent prop drilling

Co-authored-by: @soey