### PR TITLE
fix: db:seeds:fill only for one organization

### DIFF
--- a/db/seeds/fill.rb
+++ b/db/seeds/fill.rb
@@ -15,6 +15,7 @@ images = 10.times.map { URI(Faker::Avatar.image(size: '50x50', format: 'png', se
 
 FactoryBot.modify do
   factory :contributor do
+    organization { Organization.singleton }
     data_processing_consent { true }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
@@ -35,6 +36,7 @@ contributors = FactoryBot.create_list(:contributor, contributors_count)
 
 FactoryBot.modify do
   factory :request do
+    organization { Organization.singleton }
     title { Faker::Lorem.question }
     text { Faker::Lorem.paragraph }
     user { users.sample }


### PR DESCRIPTION
Motivation
----------
I used these seeds to review #1964. What I observed is that the list of requests is visible across all organizations but the search is scoped. I.e. if you search, you have no search results.

That's why I updated the seeds here, to check if the error persists for only one organization. Answer: no

How to test
-----------
1. `git switch main` or `git switch update_seeds_fill`
1. `bin/rails db:seeds:fill`
2. Do a full text search
3. On `main` you won't see anything but on this branch you will