### PR TITLE
Add many-to-many relationship between users and organizations

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,6 @@ module Admin
   class UsersController < Admin::ApplicationController
     def create
       user = User.new(resource_params)
-      user.organization = Organization.last unless user.admin?
 
       if user.save
         redirect_to admin_users_path(user), flash: { success: 'User was successfully created.' }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include Clearance::Controller
-  before_action :require_login, :require_otp_setup
-  before_action :set_organization
+  before_action :require_login, :require_otp_setup, :set_organization, :user_permitted?
 
   def require_otp_setup
     redirect_to otp_setup_path if signed_in? && !current_user.otp_enabled?
@@ -14,7 +13,7 @@ class ApplicationController < ActionController::Base
 
     super(user) do |status|
       if status.success?
-        redirect_to organizations_path
+        redirect_to redirect_path
       else
         flash.now.alert = status.failure_message
         render template: 'sessions/new', status: :unauthorized
@@ -34,9 +33,21 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def user_permitted?
+    raise ActionController::RoutingError, 'Not Found' unless current_user.admin? || @organization.in?(current_user.organizations)
+  end
+
   def set_organization
     @organization = Organization.find(params[:organization_id]) if params[:organization_id].present?
   rescue ActiveRecord::RecordNotFound
     raise ActionController::RoutingError, 'Not Found'
+  end
+
+  def redirect_path
+    if current_user.admin? || current_user.organizations.count > 1
+      organizations_path
+    else
+      organization_dashboard_path(current_user.organizations.first)
+    end
   end
 end

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OnboardingController < ApplicationController
-  skip_before_action :require_login
+  skip_before_action :require_login, :user_permitted?
   before_action :ensure_onboarding_allowed
   before_action :verify_jwt, except: :success
   before_action :resume_telegram_onboarding, only: %i[index show]

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class OrganizationsController < ApplicationController
-  skip_before_action :set_organization
+  skip_before_action :user_permitted?, :set_organization
   layout 'minimal'
 
   def index
-    # TODO: change this when having a organization habtm user relation
-    redirect_to organization_dashboard_path(current_user.organization) if current_user.organization.present?
-
     @organizations = Organization.all
+  end
+
+  def set_organization
+    organization = Organization.find(params[:organization_id])
+    redirect_to organization_dashboard_path(organization)
   end
 end

--- a/app/controllers/otp_auth_controller.rb
+++ b/app/controllers/otp_auth_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class OtpAuthController < ApplicationController
-  skip_before_action :require_login
-  skip_before_action :require_otp_setup
+  skip_before_action :require_login, :require_otp_setup, :user_permitted?, :set_organization
   before_action :redirect_if_signed_in, :redirect_unless_user_set, :reset_when_inactive
 
   layout 'minimal'
@@ -36,6 +35,6 @@ class OtpAuthController < ApplicationController
   end
 
   def redirect_if_signed_in
-    redirect_to organizations_path if signed_in?
+    redirect_to redirect_path if signed_in?
   end
 end

--- a/app/controllers/otp_setup_controller.rb
+++ b/app/controllers/otp_setup_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OtpSetupController < ApplicationController
-  skip_before_action :require_otp_setup
+  skip_before_action :require_otp_setup, :user_permitted?, :set_organization
   before_action :redirect_if_set_up
 
   layout 'minimal'
@@ -14,7 +14,7 @@ class OtpSetupController < ApplicationController
       current_user.save!
       session[:otp_verified_for_user] = current_user.id
 
-      redirect_back_or organizations_path
+      redirect_back_or redirect_path
     else
       flash.now[:error] = I18n.t('sessions.errors.otp_incorrect')
       render :show, status: :unauthorized
@@ -24,7 +24,7 @@ class OtpSetupController < ApplicationController
   private
 
   def redirect_if_set_up
-    redirect_to organizations_path if current_user.otp_enabled?
+    redirect_to redirect_path if current_user.otp_enabled?
   end
 
   def otp_params

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PasswordsController < Clearance::PasswordsController
-  skip_before_action :require_login
+  skip_before_action :require_login, :user_permitted?, :set_organization
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -7,7 +7,7 @@ class ProfileController < ApplicationController
 
   def create_user
     password = SecureRandom.alphanumeric(20)
-    user = User.new(user_params.merge(password: password, organization: @organization))
+    user = User.new(user_params.merge(password: password, organizations: [@organization]))
     if user.save
       redirect_to organization_profile_path(@organization), flash: { success: I18n.t('profile.user.created_successfully') }
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < Clearance::SessionsController
-  skip_before_action :require_login
-  skip_before_action :require_otp_setup
+  skip_before_action :require_login, :require_otp_setup, :user_permitted?, :set_organization
 
   def create
     user = authenticate(params)

--- a/app/controllers/threema/webhook_controller.rb
+++ b/app/controllers/threema/webhook_controller.rb
@@ -3,7 +3,7 @@
 require 'openssl'
 
 class Threema::WebhookController < ApplicationController
-  skip_before_action :require_login, :verify_authenticity_token
+  skip_before_action :require_login, :verify_authenticity_token, :user_permitted?, :set_organization
 
   attr_reader :adapter
 

--- a/app/controllers/whats_app/three_sixty_dialog_webhook_controller.rb
+++ b/app/controllers/whats_app/three_sixty_dialog_webhook_controller.rb
@@ -4,8 +4,7 @@ module WhatsApp
   class ThreeSixtyDialogWebhookController < ApplicationController
     include WhatsAppHandleCallbacks
 
-    skip_before_action :require_login, :verify_authenticity_token
-    before_action :organization
+    skip_before_action :require_login, :verify_authenticity_token, :user_permitted?
 
     # rubocop:disable Metrics/AbcSize
     def message
@@ -56,10 +55,6 @@ module WhatsApp
     end
 
     private
-
-    def organization
-      @organization ||= Organization.find(params['organization_id'])
-    end
 
     def message_params
       params.permit({ three_sixty_dialog_webhook:

--- a/app/controllers/whats_app/webhook_controller.rb
+++ b/app/controllers/whats_app/webhook_controller.rb
@@ -6,7 +6,7 @@ module WhatsApp
   class WebhookController < ApplicationController
     include WhatsAppHandleCallbacks
 
-    skip_before_action :require_login, :verify_authenticity_token
+    skip_before_action :require_login, :verify_authenticity_token, :user_permitted?
     before_action :set_organization, only: :status
     before_action :set_contributor, only: :status
 

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -13,7 +13,8 @@ class UserDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     deactivated_at: Field::DateTime,
-    active: Field::Boolean
+    active: Field::Boolean,
+    organizations: Field::HasMany
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
@@ -45,6 +46,7 @@ class UserDashboard < Administrate::BaseDashboard
     admin
     otp_enabled
     active
+    organizations
   ].freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,7 +10,7 @@ class Organization < ApplicationRecord
   belongs_to :business_plan
   belongs_to :contact_person, class_name: 'User', optional: true
   has_many :users_organizations, dependent: :destroy
-  has_many :users, through: :users_organizations, dependent: :destroy
+  has_many :users, through: :users_organizations, dependent: :restrict_with_exception
   has_many :contributors, dependent: :destroy
   has_many :requests, dependent: :destroy
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,7 +10,7 @@ class Organization < ApplicationRecord
   belongs_to :business_plan
   belongs_to :contact_person, class_name: 'User', optional: true
   has_many :users_organizations, dependent: :destroy
-  has_many :users, through: :users_organizations, dependent: :restrict_with_exception
+  has_many :users, through: :users_organizations
   has_many :contributors, dependent: :destroy
   has_many :requests, dependent: :destroy
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,7 +9,8 @@ class Organization < ApplicationRecord
 
   belongs_to :business_plan
   belongs_to :contact_person, class_name: 'User', optional: true
-  has_many :users, class_name: 'User', dependent: :destroy
+  has_many :users_organizations, dependent: :destroy
+  has_many :users, through: :users_organizations, dependent: :destroy
   has_many :contributors, dependent: :destroy
   has_many :requests, dependent: :destroy
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,8 @@ class User < ApplicationRecord
            dependent: :destroy
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy
   has_many :messages, as: :sender, dependent: :destroy
-  belongs_to :organization, optional: true
+  has_many :users_organizations, dependent: :destroy
+  has_many :organizations, through: :users_organizations, dependent: :destroy
 
   has_one_time_password
   validates :password, length: { in: 8..128 }, unless: :skip_password_validation?
@@ -48,10 +49,14 @@ class User < ApplicationRecord
   private
 
   def notify_admin
-    return unless organization && User.admin(false).count > organization.business_plan.number_of_users
+    return unless organizations.any? { |organization| organization.users.admin(false).count > organization.business_plan.number_of_users }
 
     User.admin.find_each do |admin|
-      PostmarkAdapter::Outbound.send_user_count_exceeds_plan_limit_message!(admin, organization)
+      organizations.each do |organization|
+        next unless organization.users.admin(false).count > organization.business_plan.number_of_users
+
+        PostmarkAdapter::Outbound.send_user_count_exceeds_plan_limit_message!(admin, organization)
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy
   has_many :messages, as: :sender, dependent: :destroy
   has_many :users_organizations, dependent: :destroy
-  has_many :organizations, through: :users_organizations, dependent: :restrict_with_exception
+  has_many :organizations, through: :users_organizations
 
   has_one_time_password
   validates :password, length: { in: 8..128 }, unless: :skip_password_validation?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :notifications_as_mentioned, class_name: 'ActivityNotification', dependent: :destroy
   has_many :messages, as: :sender, dependent: :destroy
   has_many :users_organizations, dependent: :destroy
-  has_many :organizations, through: :users_organizations, dependent: :destroy
+  has_many :organizations, through: :users_organizations, dependent: :restrict_with_exception
 
   has_one_time_password
   validates :password, length: { in: 8..128 }, unless: :skip_password_validation?

--- a/app/models/users_organization.rb
+++ b/app/models/users_organization.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class UsersOrganization < ApplicationRecord
+  belongs_to :user
+  belongs_to :organization
+end

--- a/db/data/20240812102718_migrate_users_to_users_organizations.rb
+++ b/db/data/20240812102718_migrate_users_to_users_organizations.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MigrateUsersToUsersOrganizations < ActiveRecord::Migration[6.1]
+  def up
+    User.admin(false).find_each do |user|
+      UsersOrganization.create!(user_id: user.id, organization_id: user.organization_id)
+    end
+  end
+
+  def down
+    UsersOrganization.destroy_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20_240_730_085_839)
+DataMigrate::Data.define(version: 20_240_812_102_718)

--- a/db/migrate/20240812102032_create_users_organizations.rb
+++ b/db/migrate/20240812102032_create_users_organizations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateUsersOrganizations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users_organizations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :organization, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_26_065204) do
+ActiveRecord::Schema.define(version: 2024_08_12_102032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -336,6 +336,15 @@ ActiveRecord::Schema.define(version: 2024_07_26_065204) do
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
+  create_table "users_organizations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "organization_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["organization_id"], name: "index_users_organizations_on_organization_id"
+    t.index ["user_id"], name: "index_users_organizations_on_user_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activity_notifications", "contributors"
@@ -356,4 +365,6 @@ ActiveRecord::Schema.define(version: 2024_07_26_065204) do
   add_foreign_key "requests", "users"
   add_foreign_key "taggings", "tags"
   add_foreign_key "users", "organizations"
+  add_foreign_key "users_organizations", "organizations"
+  add_foreign_key "users_organizations", "users"
 end

--- a/db/seeds/multi_tenancy.rb
+++ b/db/seeds/multi_tenancy.rb
@@ -15,7 +15,7 @@ organizations = 3.times.collect do
   )
 end
 users = 10.times.collect do
-  FactoryBot.create(:user, organization: organizations.sample)
+  FactoryBot.create(:user, organizations: [organizations.sample])
 end
 
 # images = 10.times.map { URI(Faker::Avatar.image(size: '50x50', format: 'png', set: 'set5')) }

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
 
     after(:create) do |org, evaluator|
       if evaluator.users_count.positive?
-        org.users << create_list(:user, evaluator.users_count, organization: org)
+        org.users << create_list(:user, evaluator.users_count, organizations: [org])
         org.save!
       end
     end

--- a/spec/factories/users_organizations.rb
+++ b/spec/factories/users_organizations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :users_organization do
+    user { nil }
+    organization { nil }
+  end
+end

--- a/spec/jobs/mark_inactive_contributor_inactive_job_spec.rb
+++ b/spec/jobs/mark_inactive_contributor_inactive_job_spec.rb
@@ -34,9 +34,7 @@ RSpec.describe MarkInactiveContributorInactiveJob do
         context 'that does belong to the organization' do
           before do
             contributor.update(organization_id: organization.id)
-            non_admin_user.update(organization_id: organization.id)
-            organization.users << non_admin_user
-            organization.save!
+            non_admin_user.update(organizations: [organization])
           end
 
           it { is_expected.to change { contributor.reload.deactivated_at }.from(nil).to(kind_of(ActiveSupport::TimeWithZone)) }

--- a/spec/jobs/resubscribe_contributor_job_spec.rb
+++ b/spec/jobs/resubscribe_contributor_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ResubscribeContributorJob do
   describe '#perform_later(contributor_id, adapter)' do
-    let(:user) { create(:user, organization: organization) }
+    let(:user) { create(:user, organizations: [organization]) }
     let(:organization) { create(:organization) }
 
     subject { -> { described_class.new.perform(organization.id, contributor.id, adapter) } }

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Contributor, type: :model do
                      organization: organization, user: user)
   end
   let(:organization) { create(:organization) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:contributor) { create(:contributor, email: 'contributor@example.org', organization: organization) }
 
   it 'is sorted in alphabetical order' do
@@ -952,7 +952,7 @@ RSpec.describe Contributor, type: :model do
     subject { create(:contributor, organization: organization) }
 
     before do
-      users = create_list(:user, 5, organization: organization)
+      users = create_list(:user, 5, organizations: [organization])
       organization.update(users: users)
       create(:user, admin: true)
     end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Contributor, type: :model do
                      organization: organization, user: user)
   end
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organizations: [organization]) }
+  let!(:user) { create(:user, organizations: [organization]) }
   let(:contributor) { create(:contributor, email: 'contributor@example.org', organization: organization) }
 
   it 'is sorted in alphabetical order' do
@@ -428,7 +428,7 @@ RSpec.describe Contributor, type: :model do
         context 'ActivityNotifications' do
           let!(:admin) { create(:user, admin: true) }
 
-          it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+          it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
         end
       end
     end
@@ -468,7 +468,7 @@ RSpec.describe Contributor, type: :model do
         context 'ActivityNotifications' do
           let!(:admin) { create(:user, admin: true) }
 
-          it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+          it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
         end
       end
     end
@@ -521,7 +521,7 @@ RSpec.describe Contributor, type: :model do
         context 'ActivityNotifications' do
           let!(:admin) { create(:user, admin: true) }
 
-          it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+          it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
         end
       end
     end
@@ -571,7 +571,7 @@ RSpec.describe Contributor, type: :model do
         context 'ActivityNotifications' do
           let!(:admin) { create(:user, admin: true) }
 
-          it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+          it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
         end
       end
 
@@ -951,21 +951,8 @@ RSpec.describe Contributor, type: :model do
   describe '#after_create_commit' do
     subject { create(:contributor, organization: organization) }
 
-    before do
-      users = create_list(:user, 5, organizations: [organization])
-      organization.update(users: users)
-      create(:user, admin: true)
-    end
+    before { create(:user, admin: true) }
 
-    it 'behaves like an ActivityNotification' do
-      expect { subject }.to change(ActivityNotification.where(type: 'OnboardingCompleted'), :count).by(6)
-    end
-
-    it 'for each user' do
-      subject
-      recipient_ids = ActivityNotification.where(type: 'OnboardingCompleted').pluck(:recipient_id).uniq.sort
-      user_ids = User.pluck(:id).sort
-      expect(recipient_ids).to eq(user_ids)
-    end
+    it_behaves_like 'an ActivityNotification', 'OnboardingCompleted', 2
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Message, type: :model do
 
       before do
         Contributor.skip_callback(:commit, :after, :notify_recipient, raise: false)
-        organization.update!(users: create_list(:user, 5, organization: organization))
+        organization.update!(users: create_list(:user, 5, organizations: [organization]))
       end
 
       after do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Request, type: :model do
   let(:organization) { create(:organization) }
   let(:contributor) { create(:contributor, organization: organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
 
   let(:request) do
     Request.new(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe User do
   let(:organization) { create(:organization, business_plan_name: 'Editorial pro') }
-  let!(:users) { create_list(:user, 3, organization: organization) }
+  let!(:users) { create_list(:user, 3, organizations: [organization]) }
 
   describe 'validations' do
     describe '#email' do
@@ -17,7 +17,7 @@ RSpec.describe User do
   end
 
   describe '#notify_admin' do
-    subject { create(:user, organization: organization) }
+    subject { create(:user, organizations: [organization]) }
 
     context 'non-admin' do
       it 'does not schedule a job' do

--- a/spec/models/users_organization_spec.rb
+++ b/spec/models/users_organization_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UsersOrganization, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/charts_spec.rb
+++ b/spec/requests/charts_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Charts' do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let!(:user) { create(:user, organizations: [organization]) }
   let(:last_friday_midnight) { Time.zone.today.beginning_of_day.prev_occurring(:friday) }
   let(:request) { create(:request, broadcasted_at: last_friday_midnight, organization: organization) }
   let(:message) { create(:message, created_at: last_friday_midnight, request: request) }

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe '/dashboard' do
         before { user.update(organizations: [create(:organization)]) }
 
         it 'should return not found' do
-          get dashboard_url(as: user)
+          get organization_dashboard_url(organization, as: user)
           expect(response).to have_http_status(:not_found)
         end
       end
 
       describe 'Part of organization' do
         it 'should be successful' do
-          get dashboard_url(as: user)
+          get organization_dashboard_url(organization, as: user)
           expect(response).to be_successful
         end
       end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/dashboard' do
+  let(:user) { create(:user, organizations: [organization]) }
+  let(:organization) { create(:organization) }
+
+  describe 'GET /index' do
+    describe 'Permissions' do
+      describe 'Not part of organization' do
+        before { user.update(organizations: [create(:organization)]) }
+
+        it 'should return not found' do
+          get dashboard_url(as: user)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      describe 'Part of organization' do
+        it 'should be successful' do
+          get dashboard_url(as: user)
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/invites_spec.rb
+++ b/spec/requests/invites_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Invites', type: :request do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
 
   describe 'POST /invites' do
     subject { -> { post organization_invites_path(organization, as: user) } }

--- a/spec/requests/messages_request_spec.rb
+++ b/spec/requests/messages_request_spec.rb
@@ -3,9 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Messages', type: :request do
+  let(:organization) { create(:organization) }
+  let(:request) { create(:request, organization: organization) }
+
   describe 'PATCH /messages/:id/highlight' do
     let(:params) { {} }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, organizations: [organization]) }
 
     subject do
       lambda do
@@ -15,7 +18,7 @@ RSpec.describe 'Messages', type: :request do
     end
 
     describe 'given an non-highlighted message' do
-      let(:message) { create(:message, highlighted: false) }
+      let(:message) { create(:message, highlighted: false, request: request) }
 
       describe 'given highlighted=true' do
         let(:params) { { highlighted: true } }
@@ -29,7 +32,7 @@ RSpec.describe 'Messages', type: :request do
     end
 
     describe 'given a highlighted message' do
-      let(:message) { create(:message, highlighted: true) }
+      let(:message) { create(:message, highlighted: true, request: request) }
 
       describe 'given highlighted=true' do
         let(:params) { { highlighted: true } }
@@ -44,13 +47,13 @@ RSpec.describe 'Messages', type: :request do
   end
 
   describe 'GET /request' do
-    let(:user) { create(:user) }
-    let(:contributor) { create(:contributor, first_name: 'Zora', last_name: 'Zimmermann') }
+    let(:user) { create(:user, organizations: [message.organization]) }
+    let(:contributor) { create(:contributor, first_name: 'Zora', last_name: 'Zimmermann', organization: organization) }
 
     before(:each) { get(organization_message_request_url(message.organization, message, as: user)) }
 
     context 'given an inbound message' do
-      let(:message) { create(:message, sender: contributor, recipient: nil) }
+      let(:message) { create(:message, sender: contributor, recipient: nil, request: request) }
 
       it 'renders successfully' do
         expect(response).to be_successful
@@ -69,8 +72,7 @@ RSpec.describe 'Messages', type: :request do
   end
 
   describe 'POST /request' do
-    let(:user) { create(:user) }
-    let(:request) { create(:request) }
+    let(:user) { create(:user, organizations: [organization]) }
 
     subject { -> { patch(organization_message_request_url(message.organization, message, as: user), params: params) } }
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe '/messages', type: :request do
   let(:organization) { create(:organization) }
   let(:contributor) { create(:contributor, organization: organization) }
   let(:request) { create(:request, organization: organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:message) { create(:message, request: request) }
 
   describe 'GET /new' do
@@ -45,7 +45,7 @@ RSpec.describe '/messages', type: :request do
 
   describe 'PATCH /message/:id' do
     let(:previous_text) { 'Previous text' }
-    let(:message) { create(:message, creator_id: user.id, text: previous_text) }
+    let(:message) { create(:message, creator_id: user.id, text: previous_text, request: request) }
     let(:new_attrs) { { text: 'Grab your coat and get your hat' } }
     subject { -> { patch organization_message_url(message.organization, message, as: user), params: { message: new_attrs } } }
 
@@ -62,7 +62,7 @@ RSpec.describe '/messages', type: :request do
     end
 
     context 'not manually created message' do
-      let(:message) { create(:message, creator_id: nil) }
+      let(:message) { create(:message, creator_id: nil, request: request) }
 
       it 'does not update the requested message' do
         subject.call

--- a/spec/requests/otp_auth_request_spec.rb
+++ b/spec/requests/otp_auth_request_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'OTP Auth', type: :request do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:organization) { create(:organization) }
-  let!(:user) { create(:user, email: 'zora@example.org', password: '12345678', otp_enabled: true) }
+  let!(:user) { create(:user, email: 'zora@example.org', password: '12345678', otp_enabled: true, organizations: [organization]) }
 
   describe 'GET /otp_auth' do
     before(:each) { get otp_auth_path(as: user) }
     subject { response }
 
     context 'if user is already signed in' do
-      it { should redirect_to(organizations_path) }
+      it { should redirect_to(organization_dashboard_path(organization)) }
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe 'OTP Auth', type: :request do
       context 'and correct OTP' do
         let(:otp_param) { user.otp_code }
 
-        it { should redirect_to(organizations_path) }
+        it { should redirect_to(organization_dashboard_path(organization)) }
         it { should have_current_user(user) }
       end
     end

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe '/contributors' do
-  let!(:user) { create(:user, organization: organization) }
+  let!(:user) { create(:user, organizations: [organization]) }
   let(:contact_person) { create(:user) }
   let(:organization) { create(:organization, contact_person: contact_person, business_plan_name: 'Editorial pro') }
 
@@ -48,7 +48,7 @@ RSpec.describe '/contributors' do
       end
 
       describe 'exceeds number of users of plan' do
-        let!(:last_user_allocated_by_plan) { create(:user, organization: organization) }
+        let!(:last_user_allocated_by_plan) { create(:user, organizations: [organization]) }
         let!(:admin) { create(:user, admin: true) }
 
         it 'creates a user' do

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe '/contributors' do
+RSpec.describe '/profile' do
   let!(:user) { create(:user, organizations: [organization]) }
   let(:contact_person) { create(:user) }
   let(:organization) { create(:organization, contact_person: contact_person, business_plan_name: 'Editorial pro') }

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Requests', telegram_bot: :rails do
     before(:each) { allow(Request).to receive(:broadcast!).and_call_original } # is stubbed for every other test
     subject { -> { post organization_requests_path(organization, as: user), params: params } }
     let(:params) { { request: { title: 'Example Question', text: 'How do you do?', hints: ['confidential'] } } }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, organizations: [organization]) }
 
     it { should change { Request.count }.from(0).to(1) }
 
@@ -113,7 +113,7 @@ RSpec.describe 'Requests', telegram_bot: :rails do
       }
     end
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user, organizations: [organization]) }
 
     context 'broadcasted request' do
       let!(:request) { create(:request, organization: organization) }
@@ -157,10 +157,10 @@ RSpec.describe 'Requests', telegram_bot: :rails do
   end
 
   describe 'GET /{organization_id}/notifications' do
-    let(:request) { create(:request) }
+    let(:request) { create(:request, organization: organization) }
     let!(:older_message) { create(:message, request_id: request.id, created_at: 2.minutes.ago) }
     let(:params) { { last_updated_at: 1.minute.ago } }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, organizations: [organization]) }
 
     subject { -> { get notifications_organization_request_path(request.organization, request, as: user), params: params } }
 

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Searches', type: :request do
 
   describe 'GET /index' do
     it 'returns http success' do
-      get organization_search_path(organization, as: create(:user))
+      get organization_search_path(organization, as: create(:user, organizations: [organization]))
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe 'Sessions', type: :request do
   let(:otp_enabled) { false }
 
   describe 'GET /sign_in' do
-    before(:each) { get sign_in_path(as: user) }
+    before { get sign_in_path(as: user) }
     subject { response }
 
+    # This redirect comes from Clearance.configuration.redirect_url and is hard-coded in clearance initializer.
     context 'if user is already signed-in' do
       it { should redirect_to(organizations_path) }
     end
@@ -32,7 +33,7 @@ RSpec.describe 'Sessions', type: :request do
       context 'with correct email and password' do
         let(:password_param) { '12345678' }
 
-        it { should redirect_to(organizations_path) }
+        it { should redirect_to(organization_dashboard_path(organization)) }
         it { should have_current_user(user) }
       end
     end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Sessions', type: :request do
   let(:organization) { create(:organization) }
-  let!(:user) { create(:user, email: 'zora@example.org', password: '12345678', otp_enabled: otp_enabled, organization: organization) }
+  let!(:user) { create(:user, email: 'zora@example.org', password: '12345678', otp_enabled: otp_enabled, organizations: [organization]) }
   let(:otp_enabled) { false }
 
   describe 'GET /sign_in' do

--- a/spec/requests/telegram/webhook_spec.rb
+++ b/spec/requests/telegram/webhook_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Telegram::WebhookController, telegram_bot: :rails do
         it { expect { subject.call }.not_to(change { Message.count }) }
 
         context 'given a recent request' do
-          before { create(:request, organization: organization, user: create(:user)) }
+          before { create(:request, organization: organization, user: create(:user, organizations: [organization])) }
           it { expect { subject.call }.to(change { Message.count }.from(0).to(1)) }
           it { expect { subject.call }.not_to respond_with_message }
           it_behaves_like 'an ActivityNotification', 'MessageReceived', 3

--- a/spec/requests/telegram/webhook_spec.rb
+++ b/spec/requests/telegram/webhook_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Telegram::WebhookController, telegram_bot: :rails do
     )
   end
   let!(:admin) { create_list(:user, 2, admin: true) }
+  let!(:user) { create(:user, organizations: [organization]) }
   let(:bot) { organization.telegram_bot }
   let(:controller_path) do
     "/telegram/#{Telegram::Bot::RoutesHelper.token_hash(organization.telegram_bot_api_key)}"
@@ -140,10 +141,10 @@ RSpec.describe Telegram::WebhookController, telegram_bot: :rails do
         it { expect { subject.call }.not_to(change { Message.count }) }
 
         context 'given a recent request' do
-          before { create(:request, organization: organization, user: create(:user, organizations: [organization])) }
+          before { create(:request, organization: organization, user: user) }
           it { expect { subject.call }.to(change { Message.count }.from(0).to(1)) }
           it { expect { subject.call }.not_to respond_with_message }
-          it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+          it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
         end
 
         context ' message has a document' do

--- a/spec/requests/threema/webhook_spec.rb
+++ b/spec/requests/threema/webhook_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Threema::WebhookController do
   let(:threema_lookup_double) { instance_double(Threema::Lookup) }
   let!(:organization) { create(:organization, threemarb_api_identity: '*100EYES', users_count: 1) }
   let!(:admin) { create_list(:user, 2, admin: true) }
+  let!(:user) { create(:user, organizations: [organization]) }
 
   before do
     allow(Threema).to receive(:new).and_return(threema)
@@ -48,7 +49,7 @@ RSpec.describe Threema::WebhookController do
 
     context 'With known contributor' do
       let!(:contributor) { create(:contributor, :skip_validations, threema_id: 'V5EA564T', organization: organization) }
-      let!(:request) { create(:request, organization: organization, user: create(:user, organizations: [organization])) }
+      let!(:request) { create(:request, organization: organization, user: user) }
 
       before do
         allow(threema_mock).to receive(:instance_of?).with(Threema::Receive::Text).and_return(true)
@@ -60,7 +61,7 @@ RSpec.describe Threema::WebhookController do
         expect { subject }.to change(Message, :count).from(0).to(1)
       end
 
-      it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+      it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
 
       describe 'DeliveryReceipt' do
         let(:threema_mock) do
@@ -129,7 +130,7 @@ RSpec.describe Threema::WebhookController do
           expect { subject }.to change(Message, :count).from(0).to(1)
         end
 
-        it_behaves_like 'an ActivityNotification', 'MessageReceived', 3
+        it_behaves_like 'an ActivityNotification', 'MessageReceived', 4
       end
 
       describe 'Unsupported content' do

--- a/spec/requests/threema/webhook_spec.rb
+++ b/spec/requests/threema/webhook_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Threema::WebhookController do
 
     context 'With known contributor' do
       let!(:contributor) { create(:contributor, :skip_validations, threema_id: 'V5EA564T', organization: organization) }
-      let!(:request) { create(:request, organization: organization, user: create(:user)) }
+      let!(:request) { create(:request, organization: organization, user: create(:user, organizations: [organization])) }
 
       before do
         allow(threema_mock).to receive(:instance_of?).with(Threema::Receive::Text).and_return(true)

--- a/spec/support/shared_examples/activity_notifications.rb
+++ b/spec/support/shared_examples/activity_notifications.rb
@@ -6,10 +6,10 @@ RSpec.shared_examples 'an ActivityNotification' do |event_type, count|
       expect { run_action(subject) }.to change(ActivityNotification.where(type: event_type), :count).by(count)
     end
 
-    it 'for each user' do
+    it 'for each user and admin' do
       run_action(subject)
       recipient_ids = ActivityNotification.where(type: event_type).pluck(:recipient_id).uniq.sort
-      user_ids = organization.users.pluck(:id)
+      user_ids = organization.users.pluck(:id).uniq
       admin_ids = User.admin.pluck(:id)
       all_org_user_plus_admin = (user_ids + admin_ids).sort
       expect(recipient_ids).to eq(all_org_user_plus_admin)

--- a/spec/support/shared_examples/contributor_resubscribes.rb
+++ b/spec/support/shared_examples/contributor_resubscribes.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'a Contributor resubscribes' do |adapter|
   let!(:request) { create(:request, organization: organization, user: non_admin_user) }
   let!(:admin) { create_list(:user, 2, admin: true) }
-  let!(:non_admin_user) { create(:user, organization: organization) }
+  let!(:non_admin_user) { create(:user, organizations: [organization]) }
   let(:welcome_message) do
     organization.onboarding_success_text
   end

--- a/spec/support/shared_examples/contributor_unsubscribes.rb
+++ b/spec/support/shared_examples/contributor_unsubscribes.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'a Contributor unsubscribes' do |adapter|
   let!(:request) { create(:request, organization: organization, user: non_admin_user) }
   let!(:admin) { create_list(:user, 2, admin: true) }
-  let!(:non_admin_user) { create(:user, organization: organization) }
+  let!(:non_admin_user) { create(:user, organizations: [organization]) }
   let(:unsubscribe_successful_message) do
     [I18n.t('adapter.shared.unsubscribe.successful')].join("\n\n")
   end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Users' do
-  context 'as user with admin permissions' do
+  context 'as user with admin permissions', js: true do
     let(:user) { create(:user, first_name: 'Max', last_name: 'Mustermann', admin: true, password: '12345678') }
     let!(:organization) { create(:organization) }
 
@@ -15,8 +15,10 @@ RSpec.describe 'Users' do
       fill_in 'First name', with: 'Zora'
       fill_in 'Last name', with: 'Zimmermann'
       fill_in 'Email', with: 'zimmermann@example.org'
+      input = find('input[name="user[organization_ids][]"]', visible: false)
+      input.set(organization.id)
       click_on 'Sign up'
-      expect(User.find_by(email: 'zimmermann@example.org').reload.organization).to eq(organization)
+      expect(User.find_by(email: 'zimmermann@example.org').reload.organizations).to eq([organization])
 
       expect(page).to have_text('User was successfully created.')
     end
@@ -32,7 +34,7 @@ RSpec.describe 'Users' do
       check 'Admin'
 
       click_on 'Sign up'
-      expect(User.find_by(email: 'new_admin@example.org').reload.organization).to eq(nil)
+      expect(User.find_by(email: 'new_admin@example.org').reload.organizations).to eq([])
 
       expect(page).to have_text('User was successfully created.')
     end

--- a/spec/system/auth/otp_setup_spec.rb
+++ b/spec/system/auth/otp_setup_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'OTP Setup' do
   let(:password) { Faker::Internet.password(min_length: 8, max_length: 128) }
   let(:new_password) { Faker::Internet.password(min_length: 8, max_length: 128) }
   let(:otp_enabled) { true }
-  let(:user) { create(:user, email: email, password: password, otp_enabled: otp_enabled, organization: organization) }
+  let(:user) { create(:user, email: email, password: password, otp_enabled: otp_enabled, organizations: [organization]) }
 
   describe 'without 2FA set up' do
     let(:otp_enabled) { false }

--- a/spec/system/auth/password_reset_spec.rb
+++ b/spec/system/auth/password_reset_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Password Reset' do
   let(:email) { Faker::Internet.email }
   let(:password) { Faker::Internet.password(min_length: 8, max_length: 128) }
   let(:new_password) { Faker::Internet.password(min_length: 8, max_length: 128) }
-  let!(:user) { create(:user, email: email, password: password, otp_enabled: otp_enabled, organization: organization) }
+  let!(:user) { create(:user, email: email, password: password, otp_enabled: otp_enabled, organizations: [organization]) }
 
   describe 'without 2FA set up' do
     let(:otp_enabled) { false }

--- a/spec/system/auth/sign_in_spec.rb
+++ b/spec/system/auth/sign_in_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Sign in' do
   let(:email) { 'zora@example.org' }
   let(:password) { '12345678' }
   let(:otp_enabled) { true }
-  let!(:user) { create(:user, email: email, password: password, otp_enabled: otp_enabled, organization: organization) }
+  let!(:user) { create(:user, email: email, password: password, otp_enabled: otp_enabled, organizations: [organization]) }
 
   it 'editor tries to visit protected page' do
     visit organization_dashboard_path(organization)

--- a/spec/system/contributors/conversations_spec.rb
+++ b/spec/system/contributors/conversations_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Conversation interactions', js: false do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:contributor) { create(:contributor, email: 'contributor@example.org') }
   let(:request) { create(:request, organization: organization) }
   let(:first_received_message) do

--- a/spec/system/contributors/filter_spec.rb
+++ b/spec/system/contributors/filter_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Filter contributors' do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:organization) { create(:organization) }
   let!(:active_contributor) { create(:contributor, tag_list: ['entwickler'], organization: organization) }
   let!(:inactive_contributor) { create(:contributor, :inactive, tag_list: ['entwickler'], organization: organization) }

--- a/spec/system/contributors/profile_picture_spec.rb
+++ b/spec/system/contributors/profile_picture_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Profile pictures' do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:contributor) { create(:contributor, organization: organization) }
 
   it 'Editor uploads new picture' do

--- a/spec/system/dashboard/activity_notifications_spec.rb
+++ b/spec/system/dashboard/activity_notifications_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe 'Activity Notifications' do
     let(:otp_enabled) { true }
     let(:user) do
       create(:user, first_name: 'Johnny', last_name: 'Appleseed', email: email, password: password, otp_enabled: otp_enabled,
-                    organization: organization)
+                    organizations: [organization])
     end
     let!(:coworker) do
       create(:user, first_name: 'Coworker', last_name: 'Extraordinaire', email: coworker_email, password: password,
-                    otp_enabled: otp_enabled, organization: organization)
+                    otp_enabled: otp_enabled, organizations: [organization])
     end
     let(:request) { create(:request, user: user, organization: organization) }
     let(:contributor_without_avatar) { create(:contributor, organization: organization) }

--- a/spec/system/dashboard/index_spec.rb
+++ b/spec/system/dashboard/index_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe 'Dashboard' do
   let(:email) { Faker::Internet.email }
   let(:password) { Faker::Internet.password(min_length: 8, max_length: 128) }
   let(:otp_enabled) { true }
+  let(:organization) { create(:organization) }
   let(:user) do
     create(:user, first_name: 'Dennis', last_name: 'Schroeder', email: email, password: password, otp_enabled: otp_enabled,
-                  organization: organization)
+                  organizations: [organization])
   end
   let(:contributor) { create(:contributor) }
 

--- a/spec/system/requests/deleting_requests_spec.rb
+++ b/spec/system/requests/deleting_requests_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting requests' do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
   let!(:broadcasted_request) { create(:request, organization: organization, user: user) }
   let!(:planned_request) { create(:request, schedule_send_for: 1.hour.from_now, organization: organization, user: user) }
   let!(:another_planned_request) { create(:request, schedule_send_for: 5.minutes.from_now, organization: organization, user: user) }

--- a/spec/system/requests/editing_requests_spec.rb
+++ b/spec/system/requests/editing_requests_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Editing requests', js: true do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:sent_request) { create(:request, organization: organization) }
   let(:request_scheduled_in_future) { create(:request, schedule_send_for: 2.minutes.from_now, organization: organization) }
 

--- a/spec/system/requests/personalization_spec.rb
+++ b/spec/system/requests/personalization_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Request personalization' do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:organization) { create(:organization) }
 
   context 'given two contributors'

--- a/spec/system/requests/scheduling_requests_spec.rb
+++ b/spec/system/requests/scheduling_requests_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Scheduling requests', js: true do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:organization) { create(:organization) }
 
   context 'given contributors' do

--- a/spec/system/requests/sending_images_spec.rb
+++ b/spec/system/requests/sending_images_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Sending image files', js: true do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:organization) { create(:organization) }
 
   context 'given contributors' do

--- a/spec/system/settings/image_uploads_spec.rb
+++ b/spec/system/settings/image_uploads_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Image uploads' do
   let!(:organization) { create(:organization, project_name: 'Die Lokal-Community!') }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
   let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
 
   it 'Upload new onboarding logo' do

--- a/spec/system/settings/settings_form_spec.rb
+++ b/spec/system/settings/settings_form_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Settings' do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organizations: [organization]) }
 
   it 'Exposes certain fields only to admin' do
     visit organization_settings_path(organization, as: user)


### PR DESCRIPTION
### What changed in this PR and why

This introduces the many-to-many relationship that is a requirement for some of our clients to belong to more than one organization.

Instead of a simply HABTM, it uses `has_many, through:`. This gives us more flexibility to save information on the relationship itself. For example, how do we handle active/inactive state. One idea would be to add a `deactivated_at` in the `users_organizations` table.


### TODOs

- [ ] Add automated tests that test for a user that belongs to multiple organizations
- [x] Decide on the deactivated/reactivated logic
- [x] When an admin is creating a new user, try to find the user by their email first and do something - ie either simply add the user to the organization, or throw a validation error and direct the admin to edit the existing user. EDIT: The email is already validated for uniqueness by the clearance gem. An error is displayed if someone tries to create a user with the same email.