### PR TITLE
improvement: test flakiness

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -35,11 +35,6 @@ class Contributor < ApplicationRecord
   phony_normalize :signal_phone_number, default_country_code: 'DE'
   phony_normalize :whats_app_phone_number, default_country_code: 'DE'
 
-  # (so): We have a lot of flaky specs due to failing validations
-  # on the phone numbers. Let's try to tell PhonyRails to use the correct
-  # country code to validate the numbers and see if that fixes it.
-  PhonyRails.default_country_code = 'DE'
-
   validates :signal_phone_number, phony_plausible: true
   validates :whats_app_phone_number, phony_plausible: true
   validates :data_processing_consent, acceptance: true, unless: proc { |c| c.editor_guarantees_data_consent }

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -35,6 +35,11 @@ class Contributor < ApplicationRecord
   phony_normalize :signal_phone_number, default_country_code: 'DE'
   phony_normalize :whats_app_phone_number, default_country_code: 'DE'
 
+  # (so): We have a lot of flaky specs due to failing validations
+  # on the phone numbers. Let's try to tell PhonyRails to use the correct
+  # country code to validate the numbers and see if that fixes it.
+  PhonyRails.default_country_code = 'DE'
+
   validates :signal_phone_number, phony_plausible: true
   validates :whats_app_phone_number, phony_plausible: true
   validates :data_processing_consent, acceptance: true, unless: proc { |c| c.editor_guarantees_data_consent }

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
     trait :signal_contributor do
       after(:build) do |contributor|
         contributor.email = nil
-        contributor.signal_phone_number = Faker::PhoneNumber.cell_phone_in_e164
+        contributor.signal_phone_number = Faker::PhoneNumber.unique.cell_phone_in_e164
       end
     end
 
@@ -58,7 +58,7 @@ FactoryBot.define do
       after(:build) do |contributor|
         contributor.email = nil
         # FIXME: Faker seems to create invalid phone numbers sometimes
-        contributor.whats_app_phone_number = Faker::PhoneNumber.cell_phone_in_e164
+        contributor.whats_app_phone_number = Faker::PhoneNumber.unique.cell_phone_in_e164
       end
     end
 

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
     trait :signal_contributor do
       after(:build) do |contributor|
         contributor.email = nil
-        contributor.signal_phone_number = Faker::PhoneNumber.cell_phone
+        contributor.signal_phone_number = Faker::PhoneNumber.cell_phone_in_e164
       end
     end
 
@@ -58,7 +58,7 @@ FactoryBot.define do
       after(:build) do |contributor|
         contributor.email = nil
         # FIXME: Faker seems to create invalid phone numbers sometimes
-        contributor.whats_app_phone_number = Faker::PhoneNumber.cell_phone
+        contributor.whats_app_phone_number = Faker::PhoneNumber.cell_phone_in_e164
       end
     end
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -10,9 +10,9 @@ FactoryBot.define do
     onboarding_success_heading { File.read(File.join('config', 'locales', 'onboarding', 'success_heading.txt')) }
     onboarding_success_text { File.read(File.join('config', 'locales', 'onboarding', 'success_text.txt')) }
     onboarding_data_protection_link { 'https://tactile.news/100eyes-datenschutz/' }
-    signal_server_phone_number { Faker::PhoneNumber.cell_phone }
-    whats_app_server_phone_number { Faker::PhoneNumber.cell_phone }
-    telegram_bot_username { Faker::Internet.username }
+    signal_server_phone_number { Faker::PhoneNumber.unique.cell_phone_in_e164 }
+    whats_app_server_phone_number { Faker::PhoneNumber.unique.cell_phone_in_e164 }
+    telegram_bot_username { Faker::Internet.unique.username }
 
     transient do
       users_count { 0 }

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -38,7 +38,8 @@ Capybara.register_driver(:better_cuprite) do |app|
       browser_options: remote_chrome ? { 'no-sandbox' => nil } : {},
       inspector: true,
       headless: !ENV['HEADLESS'].in?(%w[n 0 no false]),
-      process_timeout: 20
+      process_timeout: 20,
+      timeout: 20
     }.merge(remote_options)
   )
 end

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -37,7 +37,8 @@ Capybara.register_driver(:better_cuprite) do |app|
       window_size: [1200, 800],
       browser_options: remote_chrome ? { 'no-sandbox' => nil } : {},
       inspector: true,
-      headless: !ENV['HEADLESS'].in?(%w[n 0 no false])
+      headless: !ENV['HEADLESS'].in?(%w[n 0 no false]),
+      process_timeout: 20
     }.merge(remote_options)
   )
 end

--- a/spec/system/dashboard/activity_notifications_spec.rb
+++ b/spec/system/dashboard/activity_notifications_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe 'Activity Notifications' do
       contributor_two = create(:contributor, first_name: 'Timmy', last_name: 'Timmerson', organization: organization)
 
       visit organization_dashboard_path(organization, as: user)
-      expect(page).to have_css('svg.Avatar-initials')
       expect(page).to have_text(
         "#{contributor_two.name} hat sich via #{contributor_two.channels.first.to_s.capitalize} angemeldet."
       )
       expect(page).to have_text('vor weniger als eine Minute')
       expect(page).to have_link('Zum Profil', href: organization_contributor_path(organization, contributor_two))
+      expect(page).to have_css('svg.Avatar-initials')
 
       # MessageReceived
       reply = create(:message, :inbound, text: "I'm a reply to #{request.title}", request: request, sender: contributor_without_avatar)
@@ -62,13 +62,13 @@ RSpec.describe 'Activity Notifications' do
       Timecop.travel(1.day.from_now)
       visit organization_dashboard_path(organization, as: user)
 
-      expect(page).to have_css('svg.Avatar-initials')
       expect(page).to have_text(
         "#{contributor_without_avatar.name} hat auf die Frage „#{request.title}” geantwortet."
       )
       expect(page).to have_text('vor einem Tag')
       expect(page).to have_link('Zur Antwort',
                                 href: organization_request_path(request.organization_id, request, anchor: "message-#{reply.id}"))
+      expect(page).to have_css('svg.Avatar-initials')
 
       # ChatMessageSent
       click_link('Zur Antwort', href: organization_request_path(request.organization_id, request, anchor: "message-#{reply.id}"))

--- a/spec/system/profile/index_spec.rb
+++ b/spec/system/profile/index_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe 'Profile' do
       find('label[aria-label="Editorial Enterprise"]').click
       click_button 'Upgrade Plan'
     end
+
     editorial_enterprise = business_plans[2]
     price_per_month_with_discount = number_to_currency(
       editorial_enterprise.price_per_month - (editorial_enterprise.price_per_month * organization.upgrade_discount / 100.to_f)
@@ -159,7 +160,8 @@ RSpec.describe 'Profile' do
     # valid_until set to 1 year from now
     expect(page).to have_content("Mindeslaufzeit: bis #{I18n.l(1.year.from_now, format: '%m/%Y')}")
 
-    Timecop.travel(6.months.from_now + 1.minute)
+    Timecop.travel(6.months.from_now + 3.hours.from_now)
+
     visit organization_profile_path(organization, as: user)
     expect(page).to have_content("Preis: #{number_to_currency(editorial_enterprise.price_per_month)}/Monat")
 


### PR DESCRIPTION
Try to fix phony caused flakyness... let's see..

### List of recently failed specs in CI

- [x] rspec ./spec/system/admin/auth_spec.rb:9 # Auth as signed-out user user tries to access. Reason:

```
Ferrum::ProcessTimeoutError
```

- [x] rspec ./spec/mailboxes/replies_mailbox_spec.rb:34 # RepliesMailbox given a contributor is expected not to change `Message.count`. Reason:

```
 ActiveRecord::RecordInvalid:
       Gültigkeitsprüfung ist fehlgeschlagen: Telegram bot username ist bereits vergeben
```
- [x] rspec ./spec/models/request_spec.rb:234 # Request#stats given a number of requests, replies and photos [:counts][:replies] messages from us are excluded. Reason: Also telegram bot username.

- [x] rspec ./spec/system/admin/auth_spec.rb:9 # Auth as signed-out user user tries to access. Reason: Same timeout issue
- [x] rspec ./spec/models/contributor_spec.rb:677. Reason:  Telegram bot username uniqueness
- [x] rspec ./spec/system/admin/auth_spec.rb:9 # Auth as signed-out user user tries to access. Reason: Same timeout issue
- [x] rspec ./spec/adapters/whats_app_adapter/twilio_outbound/text_spec.rb:68. Reason:

```
ActiveRecord::RecordInvalid:
       Gültigkeitsprüfung ist fehlgeschlagen: Whats app phone number ist keine gültige Nummer
```

- [x] rspec './spec/jobs/resubscribe_contributor_job_spec.rb[1:1:1:2:1:2]: Invalid Signal number
- [x] rspec ./spec/system/admin/auth_spec.rb:9 Same timeout error
- [x] rspec ./spec/system/admin/auth_spec.rb:9 Same timeout error
- [x] rspec ./spec/system/admin/stats_spec.rb:19 Telegram bot uniqueness.
- [x] rspec ./spec/system/dashboard/activity_notifications_spec.rb

```
expect(page).to have_css('svg.Avatar-initials')
       expected to find css "svg.Avatar-initials" but there were no matches
```
