### PR TITLE
Fix broken chat message footer styling

### DIFF
--- a/app/components/chat_message/chat_message.css
+++ b/app/components/chat_message/chat_message.css
@@ -89,9 +89,8 @@
   display: inline-block;
 }
 
-.ChatMessage-footer .Button:nth-child(n + 3) {
-  display: inline-block;
-  margin-left: var(--spacing-unit-s);
+.ChatMessage-footer > * {
+  margin-right: var(--spacing-unit-xs);
 }
 
 .ChatMessage-footer .ChatMessage-edit:hover {


### PR DESCRIPTION
@soey I made a comment on your PR introducing the conversations feature that your changes broke the styling of the chat message footer and it's actions. I proposed there the change that fixes it, but I think you missed implementing it because I ran into the same broken styling while reviewing another PR.

See https://github.com/tactilenews/100eyes/pull/1849#discussion_r1627566780

This PR introduces the proposed fix.