### PR TITLE
feat: adds capybara for request specs

### DIFF
--- a/spec/support/capybara_setup.rb
+++ b/spec/support/capybara_setup.rb
@@ -29,3 +29,13 @@ end)
 Capybara.server_host = '0.0.0.0'
 # Use a hostname that could be resolved in the internal Docker network
 Capybara.app_host = "http://#{Socket.gethostname}:#{Capybara.server_port}"
+
+module CapybaraPage
+  def page
+    Capybara.string(response.body)
+  end
+end
+
+RSpec.configure do |config|
+  config.include CapybaraPage, type: :request
+end


### PR DESCRIPTION
As @mattwr18 proposed according to https://thoughtbot.com/blog/faster-tests-with-capybara-and-request-specs to allow for testing response content on request specs