### PR TITLE
Fix migrations in ansible installation playbook

### DIFF
--- a/ansible/roles/installation/tasks/main.yml
+++ b/ansible/roles/installation/tasks/main.yml
@@ -73,7 +73,12 @@
   community.docker.docker_prune:
     images: yes
 
-- name: Create and migrate database
+- name: Run schema migrations
   command:
-    cmd: docker compose -f docker-compose.yml -f docker-compose.prod.yml exec app bin/rails db:migrate:with_data
+    cmd: docker compose -f docker-compose.yml -f docker-compose.prod.yml exec app bin/rails db:migrate
+    chdir: /home/ansible
+
+- name: Run data migrations
+  command:
+    cmd: docker compose -f docker-compose.yml -f docker-compose.prod.yml exec app bin/rails data:migrate
     chdir: /home/ansible


### PR DESCRIPTION
For some reason, running the schema migrations and data migrations together causing them to fail and requires an addtional step to ssh into every instance and run the data migrations after the schema migrations have run successfully. The data migrations many times rely on the schema being migrated, but it was my understanding that the db:migrate:with_data accounted for this. In practice, however, it reliably fails every time.