### PR TITLE
Remove superfluous org id from jwt in specs

### DIFF
--- a/spec/requests/onboarding/signal_spec.rb
+++ b/spec/requests/onboarding/signal_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Onboarding::Signal', type: :request do
   end
   let!(:admin) { create_list(:user, 2, admin: true) }
   let(:onboarding_allowed) { { signal: true } }
-  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding', organization_id: organization.id }) }
+  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
   let(:params) { { jwt: jwt } }
 
   describe 'GET /{organization_id}/onboarding/signal' do

--- a/spec/requests/onboarding/telegram_spec.rb
+++ b/spec/requests/onboarding/telegram_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Onboarding::Telegram', type: :request do
   end
 
   describe 'POST /{organization_id}/onboarding/telegram' do
-    let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding', organization_id: organization.id }) }
+    let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
     let(:params) { { jwt: jwt } }
     let(:data_processing_consent) { true }
     let(:additional_consent) { true }

--- a/spec/requests/onboarding/threema_spec.rb
+++ b/spec/requests/onboarding/threema_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Onboarding::Threema', type: :request do
   end
   let!(:admin) { create_list(:user, 2, admin: true) }
   let(:onboarding_allowed) { { threema: true } }
-  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding', organization_id: organization.id }) }
+  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
   let(:params) { { jwt: jwt } }
   let(:threema) { instance_double(Threema) }
   let(:threema_lookup_double) { instance_double(Threema::Lookup) }

--- a/spec/requests/onboarding/whats_app_spec.rb
+++ b/spec/requests/onboarding/whats_app_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Onboarding::Whatsapp' do
   let(:three_sixty_dialog_client_api_key) { nil }
   let(:onboarding_allowed) { { whats_app: true } }
   let(:params) { { jwt: jwt } }
-  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding', organization_id: organization.id }) }
+  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
   # onboarding should work also when a contributor in another organization has the same number
   let!(:existing_contributor) { create(:contributor, whats_app_phone_number: '+491512454567') }
 

--- a/spec/system/gdpr/modal_spec.rb
+++ b/spec/system/gdpr/modal_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'GDPR modal' do
   let(:organization) { create(:organization) }
-  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding', organization_id: organization.id }) }
+  let(:jwt) { JsonWebToken.encode({ invite_code: 'ONBOARDING_TOKEN', action: 'onboarding' }) }
 
   it 'visiting onboarding page' do
     visit organization_onboarding_path(organization, jwt: jwt)

--- a/spec/system/onboarding/index_spec.rb
+++ b/spec/system/onboarding/index_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Onboarding' do
            onboarding_allowed: { threema: true, telegram: true, email: false, signal: true, whats_app: true })
   end
   let(:invalidated_jwt) do
-    JsonWebToken.encode({ invite_code: SecureRandom.base64(16), action: 'onboarding', organization_id: organization.id })
+    JsonWebToken.encode({ invite_code: SecureRandom.base64(16), action: 'onboarding' })
   end
   let!(:invalidate_jwt) { create(:json_web_token, invalidated_jwt: invalidated_jwt) }
 
   it 'Supports onboarding new contributors' do
     # Valid JWT, no configured channels
-    jwt = JsonWebToken.encode({ invite_code: SecureRandom.base64(16), action: 'onboarding', organization_id: organization.id })
+    jwt = JsonWebToken.encode({ invite_code: SecureRandom.base64(16), action: 'onboarding' })
     visit organization_onboarding_path(organization, jwt: jwt)
 
     expect(page).to have_content('Die Seite, die du suchst, existiert nicht')
@@ -41,7 +41,7 @@ RSpec.describe 'Onboarding' do
     expect(page).to have_content("Don't panic!")
 
     # Valid JWT
-    jwt = JsonWebToken.encode({ invite_code: SecureRandom.base64(16), action: 'onboarding', organization_id: organization.id })
+    jwt = JsonWebToken.encode({ invite_code: SecureRandom.base64(16), action: 'onboarding' })
     visit organization_onboarding_path(organization, jwt: jwt)
 
     expect(page).to have_content('Cool Project')


### PR DESCRIPTION
we no longer derive the organization a contributor should be added to by the jwt since we have scoped routes. This PR is a clean up of that.

Closes #1995