### PR TITLE
[improvement] 360dialog extend request to receive message feature

### DIFF
--- a/app/adapters/whats_app_adapter/three_sixty_dialog_inbound.rb
+++ b/app/adapters/whats_app_adapter/three_sixty_dialog_inbound.rb
@@ -67,7 +67,7 @@ module WhatsAppAdapter
       trigger(REQUEST_FOR_MORE_INFO, sender) if request_for_more_info?(text)
       trigger(UNSUBSCRIBE_CONTRIBUTOR, sender) if unsubscribe_text?(text)
       trigger(RESUBSCRIBE_CONTRIBUTOR, sender) if resubscribe_text?(text)
-      trigger(REQUEST_TO_RECEIVE_MESSAGE, sender) if request_to_receive_message?(sender, text)
+      trigger(REQUEST_TO_RECEIVE_MESSAGE, sender, message) if request_to_receive_message?(sender, text)
 
       message = Message.new(text: text, sender: sender)
       message.raw_data.attach(

--- a/app/adapters/whats_app_adapter/three_sixty_dialog_outbound.rb
+++ b/app/adapters/whats_app_adapter/three_sixty_dialog_outbound.rb
@@ -118,7 +118,8 @@ module WhatsAppAdapter
           WhatsAppAdapter::ThreeSixtyDialogOutbound::Text.perform_later(organization_id: message.organization.id,
                                                                         payload: text_payload(
                                                                           recipient, message.text
-                                                                        ))
+                                                                        ),
+                                                                        message_id: message.id)
         else
           files.each do |_file|
             WhatsAppAdapter::ThreeSixtyDialog::UploadFileJob.perform_later(message_id: message.id)

--- a/spec/adapters/whats_app_adapter/three_sixty_dialog_inbound_spec.rb
+++ b/spec/adapters/whats_app_adapter/three_sixty_dialog_inbound_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe WhatsAppAdapter::ThreeSixtyDialogInbound do
       describe 'with a WhatsApp template sent' do
         before { contributor.update!(whats_app_message_template_sent_at: 1.hour.ago) }
 
-        it 'triggerd the callback' do
+        it 'triggered the callback' do
           expect(subject).to have_received(:call)
         end
       end


### PR DESCRIPTION
### What changed in this PR and Why

We now save the external id of outgoing 360dialog WhatsApp messages to the message record in the database. This allows us to:

a) Send out a previous personalized message that the contributor might have forgotten to ask for, but is still interested in responding to, and
b) Support a reply_to feature where the contributor might quote reply an older message and we can properly assign the incoming message to the correct request instead of trying to infer it solely based on the latest message they received and relying on the user to move the message to the correct request if it has been incorrectly assigned.

Closes #2031 