### PR TITLE
Fix initial deploy of new instance

### DIFF
--- a/ansible/roles/initial_setup/defaults/main.yml
+++ b/ansible/roles/initial_setup/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 create_user: ansible
 copy_local_key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
-sys_packages: [ 'curl', 'vim', 'git', 'ufw']
+sys_packages: [ 'curl', 'vim', 'git', 'ufw', 'python3-passlib']

--- a/ansible/roles/initial_setup/tasks/security.yml
+++ b/ansible/roles/initial_setup/tasks/security.yml
@@ -14,7 +14,6 @@
   command: "systemctl restart {{ item }}"
   with_items:
     - ssh
-    - sshd
 
 # UFW Setup
 - name: UFW - Allow SSH connections

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -20,9 +20,6 @@
     - role: initial_setup
     - role: gantsign.inotify
       inotify_max_user_watches: 524288
-    - role: geerlingguy.pip
-      pip_install_packages:
-        - name: passlib
     - role: geerlingguy.docker
       docker_packages_state: latest
       vars:


### PR DESCRIPTION
- sshd service is not created for Ubuntu 24 LTS
- attempting to install passlib with pip results in the externally managed error. We can install it on the Ubuntu server, as we do locally to be able to run the task Add traefik admin user with htpasswd file in the installation role.