### PR TITLE
Set up log rotation for new instances

### DIFF
--- a/ansible/roles/initial_setup/tasks/main.yml
+++ b/ansible/roles/initial_setup/tasks/main.yml
@@ -4,4 +4,5 @@
 - include_tasks: postgresql_client.yml
 - include_tasks: ansible_user.yml
 - include_tasks: upload_public_keys.yml
+- include_tasks: set_up_log_rotation.yml
 - include_tasks: security.yml

--- a/ansible/roles/initial_setup/tasks/set_up_log_rotation.yml
+++ b/ansible/roles/initial_setup/tasks/set_up_log_rotation.yml
@@ -1,0 +1,10 @@
+---
+- name: Set up rotation of rails logs
+  ansible.builtin.blockinfile:
+    # Current host being iterated over in the play. See https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#term-inventory_hostname
+    path: "/etc/logrotate.d/{{ inventory_hostname }}"
+    block: "{{ logrotate_conf }}"
+    create: true
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/roles/log_rotation/defaults/main.yml
+++ b/ansible/roles/log_rotation/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-create_user: ansible
-copy_local_key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
-sys_packages: [ 'curl', 'vim', 'git', 'ufw']
 logrotate_conf: |
           /home/ansible/log/*.log {
             daily

--- a/ansible/roles/log_rotation/tasks/main.yml
+++ b/ansible/roles/log_rotation/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Set up rotation of rails logs
+  ansible.builtin.blockinfile:
+    # Current host being iterated over in the play. See https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#term-inventory_hostname
+    path: "/etc/logrotate.d/{{ inventory_hostname }}"
+    block: "{{ logrotate_conf }}"
+    create: true
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/set_up_log_rotation.yml
+++ b/ansible/set_up_log_rotation.yml
@@ -1,0 +1,6 @@
+- hosts: webservers
+  become: true
+  become_user: root
+  become_method: sudo
+  roles: 
+    - role: log_rotation


### PR DESCRIPTION
There is also a play that has been tested for setting up log rotation for existing instances. I have tested this for the roberta instance. I have not tested the flow from the initial setup, which uses the same task since I have not set up a new instance specifically for testing it.

Closes #2083 