### PR TITLE
Fix unscoped charts data

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -27,12 +27,12 @@ class ChartsController < ApplicationController
   private
 
   def joined_inbound(group_keys)
-    group_messages(@organization.messages.unscoped.replies, group_keys).count
+    group_messages(@organization.messages.unscope(:order).replies, group_keys).count
   end
 
   def joined_outbound(group_keys)
-    grouped_requests = group_messages(@organization.requests.unscoped, group_keys).count
-    grouped_messages = group_messages(@organization.messages.unscoped.where(sender_type: [User.name, nil], broadcasted: false),
+    grouped_requests = group_messages(@organization.requests.unscope(:order), group_keys).count
+    grouped_messages = group_messages(@organization.messages.unscope(:order).direct_messages,
                                       group_keys).count
     grouped_requests.merge(grouped_messages) { |_key, oldval, newval| oldval + newval }
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -27,6 +27,7 @@ class Message < ApplicationRecord
 
   scope :replies, -> { where(sender_type: Contributor.name) }
   scope :outbound, -> { where(sender_type: [User.name, nil]) }
+  scope :direct_messages, -> { outbound.where(broadcasted: false) }
 
   delegate :name, to: :creator, allow_nil: true, prefix: true
 

--- a/spec/factories/direct_messages.rb
+++ b/spec/factories/direct_messages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :direct_message, parent: :message do
+    outbound
+    broadcasted { false }
+  end
+end


### PR DESCRIPTION
We originally added the unscoped due to an error using the groupdate gem and default scopes with postgresql. See https://github.com/ankane/groupdate/issues/246

The solution was to remove all scopes because at the time the only scope was the default order; however, this introduced a bug when we moved to multi-tenancy and wanted to add the scope for the organization. The cleaner sollution was always to remove only the order scope as is done in this PR. See https://github.com/ankane/groupdate?tab=readme-ov-file#default-scopes

The PR also adds tests that expose the bug and reorganize the tests to meke them slightly more readable.

It adds a new scope that returns direct messages.

Fixes #2085