### PR TITLE
Add tests for quote reply previous request

### DIFF
--- a/spec/adapters/whats_app_adapter/three_sixty_dialog_inbound_spec.rb
+++ b/spec/adapters/whats_app_adapter/three_sixty_dialog_inbound_spec.rb
@@ -215,23 +215,42 @@ RSpec.describe WhatsAppAdapter::ThreeSixtyDialogInbound do
         end
       end
 
-      context 'given a reaction' do
-        let(:whats_app_message) { whats_app_reaction }
+      context 'given a quote_reply_message_id' do
+        let(:newer_message) { create(:message, :outbound, request: create(:request), recipient: contributor) }
+        let(:older_message) do
+          create(:message, :outbound, external_id: 'wamid.HBgNNDkxNTE0MzQxNjI2NRUCABEYEjAwNEM1QzE4M0IxNUFDRTAxQgA=', request: request,
+                                      recipient: contributor)
+        end
 
-        context 'given a message with the external id the emoji is reacting to is not the latest request' do
-          let(:newer_message) { create(:message, :outbound, request: create(:request), recipient: contributor) }
-          let(:older_message) do
-            create(:message, :outbound, external_id: 'wamid.HBgNNDkxNTE0MzQxNjI2NRUCABEYEjAwNEM1QzE4M0IxNUFDRTAxQgA=', request: request,
-                                        recipient: contributor)
+        before do
+          older_message
+          newer_message
+        end
+
+        context 'given a reaction' do
+          context 'given a message with the external id the emoji is reacting to is not the latest request' do
+            let(:whats_app_message) { whats_app_reaction }
+
+            it 'is expected to attach their latest request' do
+              expect(reply.request).to eq(older_message.request)
+            end
           end
+        end
 
+        context 'given a quote reply' do
           before do
-            older_message
-            newer_message
+            whats_app_message[:messages].first.merge!({
+                                                        context: {
+                                                          from: '+4912345578',
+                                                          id: 'wamid.HBgNNDkxNTE0MzQxNjI2NRUCABEYEjAwNEM1QzE4M0IxNUFDRTAxQgA='
+                                                        }
+                                                      })
           end
 
-          it 'is expected to attach their latest request' do
-            expect(reply.request).to eq(older_message.request)
+          context 'given a message with the external id the emoji is reacting to is not the latest request' do
+            it 'is expected to attach their latest request' do
+              expect(reply.request).to eq(older_message.request)
+            end
           end
         end
       end


### PR DESCRIPTION
With https://github.com/tactilenews/100eyes/pull/2123, the changes opened the possibility for properly assigning an incoming message to the correct request. That was the idea behind https://github.com/tactilenews/100eyes/pull/2089/commits/5da7eb560a391990a25b51b1bd6b85b010862dec was to introduce this feature, but it didn't seem to work because we didn't seem to receive the id in the incoming webhook's payload. I found that strange since we do for a quote reply/response with a quick reply button to a template. 

I reached out to 360dialog support and the AI said that in fact we do not receive the id of the message they are quote replying.

However, while working on the reactions, I saw we do receive it for reactions and double checked it for quote replies and we do seem to. Not sure if we do in every case, or if something has changed, but I tested this manually as well and it works as expected.