### PR TITLE
Fix incorrect request recipients stats

### DIFF
--- a/app/activity_notifications/request_scheduled.rb
+++ b/app/activity_notifications/request_scheduled.rb
@@ -28,7 +28,7 @@ class RequestScheduled < Noticed::Base
       request_title: request.title,
       date: I18n.l(request.schedule_send_for, format: '%A, %-d.%-m.%Y'),
       time: I18n.l(request.schedule_send_for, format: '%H:%M'),
-      contributors_count: request.organization.contributors.active.with_tags(request.tag_list).count).html_safe
+      contributors_count: request.recipients.count).html_safe
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/app/activity_notifications/request_scheduled.rb
+++ b/app/activity_notifications/request_scheduled.rb
@@ -24,11 +24,12 @@ class RequestScheduled < Noticed::Base
   # rubocop:disable Rails/OutputSafety
   def group_message(notifications:)
     request = notifications.first.request
+    recipients = request.recipients.count.positive? ? request.recipients : organization.contributors.active.with_tags(request.tag_list)
     t('.text_html',
       request_title: request.title,
       date: I18n.l(request.schedule_send_for, format: '%A, %-d.%-m.%Y'),
       time: I18n.l(request.schedule_send_for, format: '%H:%M'),
-      contributors_count: request.recipients.count).html_safe
+      contributors_count: recipients.count).html_safe
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/app/components/request_metrics/request_metrics.rb
+++ b/app/components/request_metrics/request_metrics.rb
@@ -21,7 +21,7 @@ module RequestMetrics
       [
         {
           value: stats[:counts][:contributors],
-          total: request_for_info.organization.contributors.active.with_tags(request_for_info.tag_list).count,
+          total: stats[:counts][:recipients],
           label: I18n.t('components.request_metrics.contributors', count: stats[:counts][:contributors]),
           icon: 'single-03'
         },

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -30,6 +30,7 @@ class Message < ApplicationRecord
   scope :replies, -> { where(sender_type: Contributor.name) }
   scope :outbound, -> { where(sender_type: [User.name, nil]) }
   scope :direct_messages, -> { outbound.where(broadcasted: false) }
+  scope :broadcasted_messages, -> { where(broadcasted: true) }
   scope :with_request_attached, -> { where.not(request_id: nil) }
 
   delegate :name, to: :creator, allow_nil: true, prefix: true

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -31,6 +31,7 @@ class Request < ApplicationRecord
 
   delegate :replies, to: :messages
   delegate :outbound, to: :messages
+  delegate :broadcasted_messages, to: :messages
 
   def personalized_text(contributor)
     replace_placeholder(text, I18n.t('request.personalization.first_name'), contributor.first_name.strip)
@@ -39,12 +40,16 @@ class Request < ApplicationRecord
   def stats
     {
       counts: {
-        recipients: outbound.select(:recipient_id).distinct.count,
+        recipients: recipients.count,
         contributors: replies.select(:sender_id).distinct.count,
         photos: replies.sum(:photos_count),
         replies: replies_count
       }
     }
+  end
+
+  def recipients
+    broadcasted_messages.select(:recipient_id).distinct
   end
 
   def trigger_broadcast

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Request, type: :model do
       before(:each) do
         create_list(:message, 2)
         delivered_messages = create_list(:message, 7, :outbound, request: request, broadcasted: true)
-        create(:message, :with_file, :outbound, request: request, broadcasted: false, attachment: fixture_file_upload('example-image.png'))
+        create(:message, :with_file, :outbound, request: request, broadcasted: true, attachment: fixture_file_upload('example-image.png'))
         # _ is some unresponsive recipient
         responsive_recipient, _, *other_recipients = delivered_messages.map(&:recipient)
         create_list(:message, 3, request: request, sender: responsive_recipient)


### PR DESCRIPTION
In the RequestMetrics and RequestScheduled the recipients stat was
  calculating based on the current number of active contributors that
the request would go out if created now; however, we are not interested in that number here. What we are interested in is how many people it actually went out to. Before creating a new request, it is interesting to know how many it will go out to, but not after it is already sent.

This PR also unifies the API for this stat since it is used in three separate places and this is the second time we have had a bug reported that the values were not in sync.