### PR TITLE
[improvement]: Delay marking whats app contributors inactive

### DIFF
--- a/app/adapters/postmark_adapter/outbound.rb
+++ b/app/adapters/postmark_adapter/outbound.rb
@@ -13,7 +13,7 @@ module PostmarkAdapter
         contributor = organization.contributors.find_by(email: email_address)
         next unless contributor
 
-        MarkInactiveContributorInactiveJob.perform_later(organization_id: organization.id, contributor_id: contributor.id)
+        MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
       end
     end
 

--- a/app/adapters/signal_adapter/api.rb
+++ b/app/adapters/signal_adapter/api.rb
@@ -3,7 +3,7 @@
 module SignalAdapter
   class Api
     class << self
-      def perform_request(_organization, request, contributor)
+      def perform_request(request, contributor)
         uri = request.uri
         response = Net::HTTP.start(uri.host, uri.port) do |http|
           http.request(request)

--- a/app/adapters/signal_adapter/outbound/file.rb
+++ b/app/adapters/signal_adapter/outbound/file.rb
@@ -16,7 +16,7 @@ module SignalAdapter
                                         'Content-Type': 'application/json'
                                       })
         request.body = data.to_json
-        SignalAdapter::Api.perform_request(organization, request, message.recipient) do |response|
+        SignalAdapter::Api.perform_request(request, message.recipient) do |response|
           datetime = Time.zone.at(JSON.parse(response.body)['timestamp'].to_i / 1000).to_datetime
 
           message.update(sent_at: datetime, external_id: JSON.parse(response.body)['timestamp'])

--- a/app/adapters/signal_adapter/outbound/text.rb
+++ b/app/adapters/signal_adapter/outbound/text.rb
@@ -19,7 +19,7 @@ module SignalAdapter
                                         'Content-Type': 'application/json'
                                       })
         request.body = data.to_json
-        SignalAdapter::Api.perform_request(organization, request, recipient) do |response|
+        SignalAdapter::Api.perform_request(request, recipient) do |response|
           datetime = Time.zone.at(JSON.parse(response.body)['timestamp'].to_i / 1000).to_datetime
 
           message&.update(sent_at: datetime, external_id: JSON.parse(response.body)['timestamp'])

--- a/app/adapters/telegram_adapter/outbound/photo.rb
+++ b/app/adapters/telegram_adapter/outbound/photo.rb
@@ -10,8 +10,7 @@ module TelegramAdapter
         contributor = message&.recipient
         return unless contributor
 
-        MarkInactiveContributorInactiveJob.perform_later(organization_id: job.arguments.first[:organization_id],
-                                                         contributor_id: contributor.id)
+        MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
       end
 
       attr_reader :telegram_id, :message

--- a/app/adapters/telegram_adapter/outbound/text.rb
+++ b/app/adapters/telegram_adapter/outbound/text.rb
@@ -10,8 +10,7 @@ module TelegramAdapter
         contributor = message&.recipient
         return unless contributor
 
-        MarkInactiveContributorInactiveJob.perform_later(organization_id: job.arguments.first[:organization_id],
-                                                         contributor_id: contributor.id)
+        MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
       end
 
       def perform(contributor_id:, text:, message: nil)

--- a/app/adapters/threema_adapter/outbound/file.rb
+++ b/app/adapters/threema_adapter/outbound/file.rb
@@ -34,7 +34,7 @@ module ThreemaAdapter
           threema_id = exception.message.split('Threema ID').last.strip
           contributor = organization.contributors.where('lower(threema_id) = ?', threema_id.downcase).first
 
-          MarkInactiveContributorInactiveJob.perform_later(organization_id: organization.id, contributor_id: contributor.id)
+          MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
         end
         ErrorNotifier.report(exception, tags: tags)
       end

--- a/app/adapters/threema_adapter/outbound/text.rb
+++ b/app/adapters/threema_adapter/outbound/text.rb
@@ -29,7 +29,7 @@ module ThreemaAdapter
           threema_id = exception.message.split('Threema ID').last.strip
           contributor = organization.contributors.where('lower(threema_id) = ?', threema_id.downcase).first
 
-          MarkInactiveContributorInactiveJob.perform_later(organization_id: organization.id, contributor_id: contributor.id)
+          MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id)
         end
         ErrorNotifier.report(exception, tags: tags)
       end

--- a/app/controllers/whats_app/webhook_controller.rb
+++ b/app/controllers/whats_app/webhook_controller.rb
@@ -159,7 +159,7 @@ module WhatsApp
       return unless @contributor
 
       if status_params['ErrorCode'].to_i.eql?(INVALID_MESSAGE_RECIPIENT_ERROR_CODE)
-        MarkInactiveContributorInactiveJob.perform_later(organization_id: @organization.id, contributor_id: @contributor.id)
+        MarkInactiveContributorInactiveJob.perform_later(contributor_id: @contributor.id)
         return
       end
       if status_params['ErrorCode'].to_i.eql?(FREEFORM_MESSAGE_NOT_ALLOWED_ERROR_CODE) && status_params['MessageStatus'].eql?('failed')

--- a/app/jobs/mark_inactive_contributor_inactive_job.rb
+++ b/app/jobs/mark_inactive_contributor_inactive_job.rb
@@ -3,12 +3,9 @@
 class MarkInactiveContributorInactiveJob < ApplicationJob
   queue_as :mark_inactive_contributor_inactive
 
-  def perform(organization_id:, contributor_id:)
-    organization = Organization.find_by(id: organization_id)
-    return unless organization
-
-    contributor = organization.contributors.where(id: contributor_id).first
-    return unless contributor
+  def perform(contributor_id:)
+    contributor = Contributor.find(contributor_id)
+    organization = contributor.organization
 
     contributor.deactivated_at = Time.current
     contributor.save(validate: false)

--- a/app/jobs/whats_app_adapter/handle_failed_message_job.rb
+++ b/app/jobs/whats_app_adapter/handle_failed_message_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WhatsAppAdapter
+  class HandleFailedMessageJob < ApplicationJob
+    def perform(contributor_id:, external_message_id:)
+      contributor = Contributor.find(contributor_id)
+      message = Message.find_by(external_id: external_message_id) || Message::WhatsAppTemplate.find_by(external_id: external_message_id)
+      return if message && message.delivered_at.present?
+
+      contributor.whats_app_message_failed_count += 1
+      contributor.save!
+      MarkInactiveContributorInactiveJob.perform_later(contributor_id: contributor.id) if contributor.whats_app_message_failed_count >= 3
+    end
+  end
+end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -173,7 +173,8 @@ class Contributor < ApplicationRecord
     update!(
       deactivated_at: nil,
       deactivated_by_user_id: nil,
-      deactivated_by_admin: false
+      deactivated_by_admin: false,
+      whats_app_message_failed_count: 0
     )
   end
 

--- a/db/migrate/20250417113224_add_whats_app_message_failed_count_to_contributors.rb
+++ b/db/migrate/20250417113224_add_whats_app_message_failed_count_to_contributors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWhatsAppMessageFailedCountToContributors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contributors, :whats_app_message_failed_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_11_113532) do
+ActiveRecord::Schema.define(version: 2025_04_17_113224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2025_02_11_113532) do
     t.datetime "unsubscribed_at"
     t.string "signal_uuid"
     t.string "signal_onboarding_token"
+    t.integer "whats_app_message_failed_count", default: 0
     t.index ["organization_id", "email"], name: "idx_org_email", unique: true
     t.index ["organization_id", "signal_phone_number"], name: "idx_org_signal_phone_number", unique: true
     t.index ["organization_id", "telegram_id"], name: "idx_org_telegram_id", unique: true

--- a/spec/adapters/signal_adapter/api_spec.rb
+++ b/spec/adapters/signal_adapter/api_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe SignalAdapter::Api do
         before(:each) do
           stub_request(:post, uri).to_return(status: 200)
         end
-        specify { expect { |block| api.perform_request(organization, request, recipient, &block) }.to yield_control }
+        specify { expect { |block| api.perform_request(request, recipient, &block) }.to yield_control }
 
         describe 'ErrorNotifier' do
           subject { ErrorNotifier }
-          before { api.perform_request(organization, request, recipient) }
+          before { api.perform_request(request, recipient) }
           it { should_not have_received(:report) }
         end
       end
@@ -35,11 +35,11 @@ RSpec.describe SignalAdapter::Api do
           stub_request(:post, uri).to_return(status: 400, body: { error: 'Ouch!' }.to_json)
         end
 
-        specify { expect { |block| api.perform_request(organization, request, recipient, &block) }.not_to yield_control }
+        specify { expect { |block| api.perform_request(request, recipient, &block) }.not_to yield_control }
 
         describe 'ErrorNotifier' do
           subject { ErrorNotifier }
-          before { api.perform_request(organization, request, recipient) }
+          before { api.perform_request(request, recipient) }
           it { should have_received(:report) }
         end
 
@@ -51,7 +51,7 @@ RSpec.describe SignalAdapter::Api do
             stub_request(:post, uri).to_return(status: 400, body: { error: 'Unregistered user' }.to_json)
           end
 
-          subject { -> { api.perform_request(organization, request, recipient) } }
+          subject { -> { api.perform_request(request, recipient) } }
 
           it {
             is_expected.to have_enqueued_job(MarkInactiveContributorInactiveJob).with do |params|

--- a/spec/adapters/signal_adapter/api_spec.rb
+++ b/spec/adapters/signal_adapter/api_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe SignalAdapter::Api do
 
           it {
             is_expected.to have_enqueued_job(MarkInactiveContributorInactiveJob).with do |params|
-              expect(params[:organization_id].to(eq(organization.id)))
               expect(params[:contributor_id].to(eq(recipient.id)))
             end
           }

--- a/spec/adapters/threema_adapter/outbound/file_spec.rb
+++ b/spec/adapters/threema_adapter/outbound/file_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe ThreemaAdapter::Outbound::File do
 
       it 'enqueues a job to mark inactive contributor inactive' do
         expect { subject.call }.to have_enqueued_job(MarkInactiveContributorInactiveJob).with(
-          organization_id: organization.id,
           contributor_id: contributor.id
         )
       end

--- a/spec/adapters/threema_adapter/outbound/text_spec.rb
+++ b/spec/adapters/threema_adapter/outbound/text_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe ThreemaAdapter::Outbound::Text do
 
       it 'enqueues a job to mark inactive contributor inactive' do
         expect { subject.call }.to have_enqueued_job(MarkInactiveContributorInactiveJob).with(
-          organization_id: organization.id,
           contributor_id: contributor.id
         )
       end

--- a/spec/jobs/mark_inactive_contributor_inactive_job_spec.rb
+++ b/spec/jobs/mark_inactive_contributor_inactive_job_spec.rb
@@ -4,52 +4,33 @@ require 'rails_helper'
 
 RSpec.describe MarkInactiveContributorInactiveJob do
   describe '#perform_later(contributor_id:)' do
-    subject { -> { described_class.new.perform(organization_id: organization.id, contributor_id: contributor.id) } }
+    subject { -> { described_class.new.perform(contributor_id: contributor.id) } }
 
     let!(:admin) { create_list(:user, 2, admin: true) }
     let!(:non_admin_user) { create(:user) }
-
-    context 'given an unknown organization and unknown contributor' do
-      let(:organization) { Organization.new(id: 12_345) }
-      let(:contributor) { Contributor.new(id: 12_345) }
-
-      it 'does not throw an error' do
-        expect { subject.call }.not_to raise_error
-      end
-
-      it 'does not enqueue job' do
-        expect { subject.call }.not_to have_enqueued_job
-      end
-    end
 
     context 'given a known organization' do
       let(:organization) { create(:organization) }
       let(:contributor) { create(:contributor) }
 
       context 'given a known contributor' do
-        context 'that does not belong to the organization' do
-          it { is_expected.not_to raise_error }
+        before do
+          contributor.update(organization_id: organization.id)
+          non_admin_user.update(organizations: [organization])
         end
 
-        context 'that does belong to the organization' do
-          before do
-            contributor.update(organization_id: organization.id)
-            non_admin_user.update(organizations: [organization])
-          end
-
-          it { is_expected.to change { contributor.reload.deactivated_at }.from(nil).to(kind_of(ActiveSupport::TimeWithZone)) }
-          it_behaves_like 'an ActivityNotification', 'ContributorMarkedInactive', 3
-          it 'enqueues a job to inform admin' do
-            expect { subject.call }.to have_enqueued_job.on_queue('default').with(
-              'PostmarkAdapter::Outbound',
-              'contributor_marked_as_inactive_email',
-              'deliver_now', # How ActionMailer works in test environment, even though in production we call deliver_later
-              {
-                params: { admin: an_instance_of(User), contributor: contributor, organization: organization },
-                args: []
-              }
-            ).exactly(2).times
-          end
+        it { is_expected.to change { contributor.reload.deactivated_at }.from(nil).to(kind_of(ActiveSupport::TimeWithZone)) }
+        it_behaves_like 'an ActivityNotification', 'ContributorMarkedInactive', 3
+        it 'enqueues a job to inform admin' do
+          expect { subject.call }.to have_enqueued_job.on_queue('default').with(
+            'PostmarkAdapter::Outbound',
+            'contributor_marked_as_inactive_email',
+            'deliver_now', # How ActionMailer works in test environment, even though in production we call deliver_later
+            {
+              params: { admin: an_instance_of(User), contributor: contributor, organization: organization },
+              args: []
+            }
+          ).exactly(2).times
         end
       end
     end

--- a/spec/jobs/whats_app_adapter/handle_failed_message_job_spec.rb
+++ b/spec/jobs/whats_app_adapter/handle_failed_message_job_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WhatsAppAdapter::HandleFailedMessageJob do
+  describe '#perform_later(contributor_id:, external_message_id:)' do
+    subject { -> { described_class.new.perform(contributor_id: contributor.id, external_message_id: external_message_id) } }
+
+    let!(:contributor) { create(:contributor, :whats_app_contributor) }
+    let(:external_message_id) { nil }
+    let(:message) { create(:message) }
+
+    describe 'unknown message' do
+      it 'is expected not to raise an error' do
+        expect { subject.call }.not_to raise_error
+      end
+
+      it 'does not schedule a job to mark contributor as inactive' do
+        expect { subject.call }.not_to have_enqueued_job(MarkInactiveContributorInactiveJob)
+      end
+
+      it 'increments the whats_app_message_failed_count by 1' do
+        expect { subject.call }.to change { contributor.reload.whats_app_message_failed_count }.from(0).to(1)
+      end
+
+      context 'three failed messages' do
+        before { contributor.update(whats_app_message_failed_count: 2) }
+
+        it 'schedules a job to mark contributor inactive' do
+          expect { subject.call }.to have_enqueued_job(MarkInactiveContributorInactiveJob).with(
+            contributor_id: contributor.id
+          )
+        end
+      end
+    end
+
+    describe 'message with external_id found' do
+      let(:external_message_id) { 'wamid.<some_valid_external_message_id>' }
+
+      before { message.update(external_id: external_message_id) }
+
+      context 'given the message was not marked as delivered' do
+        it 'increments the whats_app_message_failed_count by 1' do
+          expect { subject.call }.to change { contributor.reload.whats_app_message_failed_count }.from(0).to(1)
+        end
+
+        context 'three failed messages' do
+          before { contributor.update(whats_app_message_failed_count: 2) }
+
+          it 'schedules a job to mark contributor inactive' do
+            expect { subject.call }.to have_enqueued_job(MarkInactiveContributorInactiveJob).with(
+              contributor_id: contributor.id
+            )
+          end
+        end
+      end
+
+      context 'given the message has been marked as delivered' do
+        before do
+          message.update(delivered_at: 3.hours.ago)
+          contributor.update(whats_app_message_failed_count: 2)
+        end
+
+        it 'does not increment the whats_app_message_failed_count since it is a false positive' do
+          expect { subject.call }.not_to(change { contributor.reload.whats_app_message_failed_count })
+        end
+
+        it 'does not schedule a job to mark contributor as inactive' do
+          expect { subject.call }.not_to have_enqueued_job(MarkInactiveContributorInactiveJob)
+        end
+      end
+    end
+
+    describe 'whats_app message template with external_id found' do
+      let(:external_message_id) { 'wamid.<some_valid_external_message_id>' }
+      let(:whats_app_message_template) { create(:message_whats_app_template, external_id: external_message_id, message: message) }
+
+      context 'given the whats_app message template was not marked as delivered' do
+        it 'increments the whats_app_message_failed_count by 1' do
+          expect { subject.call }.to change { contributor.reload.whats_app_message_failed_count }.from(0).to(1)
+        end
+
+        context 'three failed messages' do
+          before { contributor.update(whats_app_message_failed_count: 2) }
+
+          it 'schedules a job to mark contributor inactive' do
+            expect { subject.call }.to have_enqueued_job(MarkInactiveContributorInactiveJob).with(
+              contributor_id: contributor.id
+            )
+          end
+        end
+      end
+
+      context 'given the whats_app message template has been marked as delivered' do
+        before do
+          whats_app_message_template.update(delivered_at: 3.hours.ago)
+          contributor.update(whats_app_message_failed_count: 2)
+        end
+
+        it 'does not increment the whats_app_message_failed_count since it is a false positive' do
+          expect { subject.call }.not_to(change { contributor.reload.whats_app_message_failed_count })
+        end
+
+        it 'does not schedule a job to mark contributor as inactive' do
+          expect { subject.call }.not_to have_enqueued_job(MarkInactiveContributorInactiveJob)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -749,6 +749,14 @@ RSpec.describe Contributor, type: :model do
       it 'reactivates the contributor' do
         expect { subject }.to change { contributor.reload.deactivated_at }.from(kind_of(ActiveSupport::TimeWithZone)).to(nil)
       end
+
+      context 'given a contributor has a whats_app_failed_message_count' do
+        before { contributor.update(whats_app_message_failed_count: 3) }
+
+        it 'resets the count' do
+          expect { subject }.to change { contributor.reload.whats_app_message_failed_count }.from(3).to(0)
+        end
+      end
     end
 
     describe 'given a deactivated contributor by a user' do

--- a/spec/requests/contributors_spec.rb
+++ b/spec/requests/contributors_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe '/:organization_id/contributors', type: :request do
         expect(page).not_to have_content other_organizations_contributor.first_name
       end
     end
+
+    context 'given a WhatsApp contributor marked inactive' do
+      let(:message_explaining_reason_for_being_marked_inactive) do
+        <<~HELLO
+          Die Rufnummer wurde möglicherweise nicht bei WhatsApp registriert oder der Empfänger hat die neuen Nutzungsbedingungen und Datenschutzrichtlinien von WhatsApp nicht akzeptiert.
+        HELLO
+      end
+      let(:message_continued) do
+        <<~HELLO
+          Es ist auch möglich, dass der Empfänger eine alte, nicht unterstützte Version des WhatsApp-Clients für sein Telefon verwendet. Bitte überprüfe dies mit Johnny
+        HELLO
+      end
+      let!(:contributor) do
+        create(:contributor,
+               :whats_app_contributor,
+               organization: organization,
+               deactivated_at: Time.current.beginning_of_day,
+               first_name: 'Johnny')
+      end
+
+      it 'displays a message to inform the contributor the potential reason' do
+        subject.call
+        expect(page).to have_content(message_explaining_reason_for_being_marked_inactive.strip)
+        expect(page).to have_content(message_continued.strip)
+      end
+    end
   end
 
   describe 'GET /count' do


### PR DESCRIPTION
### What Changed in this PR and Why

* We delay marking WhatsApp contributors inactive when we receive an error that they are an invalid recipient. The reason we do this is that we mostly receive false positives where we also receive a webhook saying they received the message that generates the error. Also, we do not need to be so immediate in our response. For this reason, we also add a count and only mark them inactive if they receive 3 errors. While we agree that it's important for the client to know when a contributor cannot receive messages from us, we don't think that they need to know the minute that we know. 
* The MarkInactiveContributorInactiveJob's api changed to drop the need to pass in the organization since it can be derived from the contributor. When the job was created, we were working under the assumption that the contributor could belong to multiple organizations, but we've since changed this and we create a new contributor if they want to join a new organization in the same instance. This is an improvement because there is no chance of a mismatch between the organization passed in and the one that the contributor belongs to.

Closes #2139 